### PR TITLE
Don't use psycopg2 2.9 while we're on old Django versions

### DIFF
--- a/python-pip-requirements.txt
+++ b/python-pip-requirements.txt
@@ -29,7 +29,10 @@ idna
 libsass
 markdown
 polib
-psycopg2-binary
+# psycopg2 2.9 is incompatible with old django versions
+# see: https://github.com/psycopg/psycopg2/issues/1293#issuecomment-862835147
+# remove constraint after Django upgrade
+psycopg2-binary<2.9
 pyparsing
 pyrabbit
 pyyaml


### PR DESCRIPTION
psycopg2 2.9 is incompatible with old django versions, see: https://github.com/psycopg/psycopg2/issues/1293#issuecomment-862835147.

This commit restricts psycopg2-binary to <2.9 for now, fixing "database connection isn't set to UTC" errors. @sinteur, this constraint should be removed once Django has been upgraded.