### PR TITLE
Revert "Don't use psycopg2 2.9 while we're on old Django versions"

### DIFF
--- a/python-pip-requirements.txt
+++ b/python-pip-requirements.txt
@@ -25,8 +25,7 @@ idna
 libsass
 markdown
 polib
-# https://github.com/psycopg/psycopg2/issues/1293
-psycopg2-binary>=2.8,<2.9
+psycopg2-binary==2.9.1
 pyparsing
 pyrabbit
 pyyaml


### PR DESCRIPTION
This reverts commit 205a1e6a774fd489b848ba4b84651e9337b94cbc and pins
psycopg2-binary to the most recent release.