### PR TITLE
Remove IDNA for manual HoF.

### DIFF
--- a/checks/templates/halloffame-hosters.html
+++ b/checks/templates/halloffame-hosters.html
@@ -28,7 +28,7 @@
     <h2>{% include "string.html" with name=hof_subtitle %}</h2>
     <ul class="list-column column-3">
     {% for member in halloffame %}
-      <li><a href="{{member.permalink}}">{{member.domain|idna|truncatechars:36}}</a></li>
+      <li><a href="{{member.permalink}}">{{member.domain|truncatechars:36}}</a></li>
     {% endfor %}
     </ul>
   </div>


### PR DESCRIPTION
This was specifically removed in https://github.com/internetstandards/Internet.nl/commit/cd6a6b8aeae6049f1c2d3e62a0952e01d57dace9 because the manual (hoster) Hall of Fame uses manually entered free text instead of domain names.
This PR removes it again after it was re-introduced in https://github.com/internetstandards/Internet.nl/commit/8d26ee69ae02113fa6acf09b86288c1a19c5338e.