### PR TITLE
Remove SessionAuthenticationMiddleware per Django v2.0 release notes

### DIFF
--- a/internetnl/settings.py-dist
+++ b/internetnl/settings.py-dist
@@ -148,7 +148,6 @@ MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django_hosts.middleware.HostsResponseMiddleware',
     'internetnl.custom_middlewares.ActivateTranslationMiddleware',


### PR DESCRIPTION
Another artifact from the Django upgrade. I could not get `python manage.py runserver` to start without this.

See also https://docs.djangoproject.com/en/2.0/releases/2.0/#miscellaneous