### PR TITLE
bin/pofiles.py: catch FileNotFoundError during TAR_UNPACK_DIR deletion

### DIFF
--- a/bin/pofiles.py
+++ b/bin/pofiles.py
@@ -186,7 +186,10 @@ def build_tar(args=None):
 
     """
     print("Removing previous directory structure...")
-    shutil.rmtree(TAR_UNPACK_DIR)
+    try:
+        shutil.rmtree(TAR_UNPACK_DIR)
+    except FileNotFoundError:
+        pass
     pathlib.Path(TAR_UNPACK_DIR).mkdir(parents=True, exist_ok=True)
 
     print("Building tar from translations...")


### PR DESCRIPTION
This PR fixes the following error when attempting to convert the .po files for translation in the content repository:

```
$ make translations_tar
Removing previous directory structure...
Traceback (most recent call last):
  File "/home/user/Internet.nl/bin/pofiles.py", line 341, in <module>
    parse()
  File "/home/user/Internet.nl/bin/pofiles.py", line 337, in parse
    args.func(args)
  File "/home/user/Internet.nl/bin/pofiles.py", line 189, in build_tar
    shutil.rmtree(TAR_UNPACK_DIR)
  File "/usr/lib/python3.9/shutil.py", line 709, in rmtree
    onerror(os.lstat, path, sys.exc_info())
  File "/usr/lib/python3.9/shutil.py", line 707, in rmtree
    orig_st = os.lstat(path)
FileNotFoundError: [Errno 2] No such file or directory: 'locale_files'
make: *** [Makefile:39: translations_tar] Error 1
```