### PR TITLE
Workaround for issue #635 (replace pyrabbit w/ pyrabbit2)

### DIFF
--- a/checks/batch/scheduler.py
+++ b/checks/batch/scheduler.py
@@ -9,9 +9,9 @@ from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
-from pyrabbit import Client
-from pyrabbit.http import HTTPError, NetworkError
-from pyrabbit.api import APIError, PermissionError
+from pyrabbit2 import Client
+from pyrabbit2.http import HTTPError, NetworkError
+from pyrabbit2.api import APIError, PermissionError
 
 from . import util
 from .. import batch_shared_task, redis_id

--- a/python-pip-requirements.txt
+++ b/python-pip-requirements.txt
@@ -28,7 +28,6 @@ markdown
 polib
 psycopg2-binary==2.9.1
 pyparsing
-pyrabbit
 pyrabbit2
 pyyaml
 rjsmin

--- a/python-pip-requirements.txt
+++ b/python-pip-requirements.txt
@@ -29,6 +29,7 @@ polib
 psycopg2-binary==2.9.1
 pyparsing
 pyrabbit
+pyrabbit2
 pyyaml
 rjsmin
 pythonwhois


### PR DESCRIPTION
This is a workaround for issue #635 I used while working on the batch test code for #30 

pyrabbit has been unmaintained for some time. It has been forked as
'pyrabbit2'. Unfortunately, Celery dependency kombu depends on pyrabbit
itself, so this workaround effectively adds a copy of a fork :-(

Signed-off-by: Maarten Aertsen <maarten.aertsen@ncsc.nl>