### PR TITLE
batch: Migrate deprecated use of ForeignObjectRel.to attribute

### DIFF
--- a/checks/batch/scheduler.py
+++ b/checks/batch/scheduler.py
@@ -158,7 +158,7 @@ def check_for_result_or_start_test(batch_domain, batch_test, subtest, taskset):
 
     """
     started_test = False
-    subtest_model = batch_test._meta.get_field(subtest).rel.to
+    subtest_model = batch_test._meta.get_field(subtest).remote_field.model
     result = find_result(batch_domain, subtest_model)
     if result:
         save_result(batch_test, subtest, result)
@@ -307,7 +307,7 @@ def get_common_report(batch_domain):
 
     if common_report_ids:
         common_report_id = max(common_report_ids)
-        report_model = batch_test._meta.get_field('report').rel.to
+        report_model = batch_test._meta.get_field('report').remote_field.model
         try:
             return report_model.objects.get(id=common_report_id)
         except report_model.DoesNotExist:


### PR DESCRIPTION
@sinteur this is a leftover regression introduced by the Django upgrade. Can you please merge this commit to master? It was previously part of PR #623, but I have decided to split it out because this is a bugfix, not a quality of life improvement.