### PR TITLE
Fix #651 (Domain are vanishing from HoF)

### DIFF
--- a/interface/views/domain.py
+++ b/interface/views/domain.py
@@ -29,6 +29,7 @@ from interface.views.shared import (
     probestatuses,
     process,
     redirect_invalid_domain,
+    update_report_with_registrar_and_score,
 )
 
 # Entrance after form submission.
@@ -63,6 +64,7 @@ def siteprocess(request, dname):
 def create_report(domain, ipv6, dnssec, tls=None, appsecpriv=None):
     report = DomainTestReport(domain=domain, ipv6=ipv6, dnssec=dnssec, tls=tls, appsecpriv=appsecpriv)
     report.save()
+    update_report_with_registrar_and_score(report, webprobes)
     return report
 
 

--- a/interface/views/mail.py
+++ b/interface/views/mail.py
@@ -22,6 +22,7 @@ from interface.views.shared import (
     probestatuses,
     process,
     redirect_invalid_domain,
+    update_report_with_registrar_and_score,
 )
 
 regex_mailaddr = (
@@ -57,6 +58,7 @@ def mailprocess(request, mailaddr):
 def create_report(domain, ipv6, dnssec, auth, tls):
     report = MailTestReport(domain=domain, ipv6=ipv6, dnssec=dnssec, auth=auth, tls=tls)
     report.save()
+    update_report_with_registrar_and_score(report, mailprobes)
     return report
 
 

--- a/interface/views/shared.py
+++ b/interface/views/shared.py
@@ -219,6 +219,18 @@ def add_score_to_report(report, score):
         report.save()
 
 
+def update_report_with_registrar_and_score(report, probes):
+    """
+    Adds registrar information (from DNSSEC test if any) and score
+    to a newly created report.
+
+    """
+    probe_reports = probes.get_probe_reports(report)
+    add_registrar_to_report(report)
+    score = probes.count_probe_reports_score(probe_reports)
+    add_score_to_report(report, score)
+
+
 def get_hof_cache(cache_id, count):
     cached_data = cache.get(cache_id, None)
     if cached_data is None:


### PR DESCRIPTION
This PR fixes #651 by attaching report information like scoring right after report creation.

This is just a suggested change.
Needs review and testing (and maybe refactoring) before merging.