### PR TITLE
Fix caching behaviour in CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -56,20 +56,21 @@ jobs:
           # Prevent re-building the venv when all requirements.txts stays the same.
           # rebuild venv to make sure everything still builds ./.venv/
           path: |
+            ./.venv/
             ./unbound/
             ./_unbound/
             ./nassl_freebsd/
             ./python-whois/
-          key: ${{ runner.os }}-${{ matrix.python-version }}-venv-and-deps-${{ hashFiles('**/requirements*.txt') }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}-v3-venv-and-deps-${{ hashFiles('**/requirements*.txt', 'Makefile') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.python-version }}-venv-
+            ${{ runner.os }}-${{ matrix.python-version }}-v3-venv-
       # the venv and all (slow) custom dependencies is only built when there was no cache hit.
       - name: Setup Application Configuration
         run: |
           cp ./internetnl/settings-dist.py ./internetnl/settings.py
       - name: Make venv
         run: make venv
-        # if: steps.cache-venv.outputs.cache-hit != 'true'
+        if: steps.cache-venv.outputs.cache-hit != 'true'
       - name: Install system dependencies for unbound/nassl
         run: |
           sudo apt update

--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ unbound-3.10-github: venv .unbound-3.10-github
 .unbound-3.10-github:
 	rm -rf unbound
 	git clone https://github.com/internetstandards/unbound
-	cd unbound && ${env} ./configure --prefix=/home/$(USER)/usr/local --enable-internetnl --with-pyunbound --with-libevent --with-libhiredis PYTHON_VERSION=3.10 PYTHON_SITE_PKG=$(ROOT_DIR)/.venv/lib/python3.10/site-packages &&  make install
+	cd unbound && ${env} ./configure --prefix=$(ROOT_DIR)/_unbound/ --enable-internetnl --with-pyunbound --with-libevent --with-libhiredis PYTHON_VERSION=3.10 PYTHON_SITE_PKG=$(ROOT_DIR)/.venv/lib/python3.10/site-packages &&  make install
 	touch .unbound-3.10-github
 
 unbound-x86-3.9: .unbound-x86-3.9


### PR DESCRIPTION
- Makefile is now part of key to determine to rebuild cache
- .venv is now included in cache
- Fixed unbound install path for 3.10

venv not being part of the path could lead to being stuck with
partial unbound installs.