### PR TITLE
Ref #733 - Run CI on any push - may fix leftover cache issues

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,12 @@
 name: Internet.nl
 
-on: [ pull_request ]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - release/*
+
 
 jobs:
   build:


### PR DESCRIPTION
According to https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
GitHub only looks for a cache hit in the current (feature) branch, and then in the parent.
Since we don't build on main, there is never a cache hit in new feature branches.

We should probably be building on main anyways, and this may finally fix cache misses.