### PR TITLE
Fix #741 - Improve layout of DMARC tech table

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -1140,7 +1140,7 @@ table td {
   overflow-x: auto;
 }
 .tech-details-table table tbody td:first-child {
-  word-break: normal;
+  word-break: break-all;
 }
 
 .test-direct {


### PR DESCRIPTION
Changing this word break does affect other cases, but it doesn't seem to make them worse overall, just with slightly different breaks.

To really make this perfect, we need to define word-breaks separately for every column of every tech table for every test.