### PR TITLE
[1.6.x] Ref #769 - Update sectxt to 0.7 in 1.6.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ requests==2.28.1
     #   sectxt
 rjsmin==1.2.1
     # via -r requirements.in
-sectxt==0.6
+sectxt==0.7
     # via -r requirements.in
 selenium==3.141.0
     # via -r requirements.in


### PR DESCRIPTION
Fixes https://github.com/DigitalTrustCenter/sectxt/issues/33

Replaces #799 - this fix is only for release branch