### PR TITLE
Fix #769 - Correctly indicate probe error to user

### DIFF
--- a/checks/probes.py
+++ b/checks/probes.py
@@ -29,6 +29,7 @@ from checks.scoring import (
     STATUSES_HTML_CSS_TEXT_MAP,
 )
 from checks.tasks import dispatcher
+from checks.tasks.dispatcher import ProbeTaskResult
 
 if settings.INTERNET_NL_CHECK_SUPPORT_IPV6:
     from checks.tasks import ipv6
@@ -235,25 +236,19 @@ class Probe(object):
             verdict = STATUSES_HTML_CSS_TEXT_MAP[STATUS_FAIL]
         return verdict
 
-    def raw_results(self, dname, remote_addr):
+    def raw_results(self, dname, remote_addr) -> ProbeTaskResult:
         """
         Get results from the taskset.
         Start the taskset if not running or cached.
-        Return (done, results)-tuple where:
-            - done=bool
-            - results=Celery JSON output
-
         """
         return dispatcher.check_results(dname, self.taskset, remote_addr, get_results=True)
 
-    def check_results(self, dname, remote_addr):
+    def check_results(self, dname, remote_addr) -> ProbeTaskResult:
         """
         Get just the status of the taskset.
         Start the taskset if not running or cached.
-
         """
-        status, _ = dispatcher.check_results(dname, self.taskset, remote_addr)
-        return status
+        return dispatcher.check_results(dname, self.taskset, remote_addr, get_results=False)
 
     def rated_results(self, dname):
         """

--- a/checks/tasks/dispatcher.py
+++ b/checks/tasks/dispatcher.py
@@ -25,7 +25,7 @@ def user_limit_exceeded(req_limit_id):
     return current_usage > settings.CLIENT_RATE_LIMIT
 
 
-@dataclass
+@dataclass(frozen=True)
 class ProbeTaskResult:
     done: bool
     success: Optional[bool] = None
@@ -78,11 +78,10 @@ def check_results(url, checks_registry, remote_addr, get_results=False) -> Probe
     log.debug("Trying to retrieve asyncresult from task_id: %s.", task_id)
     results = {}
     callback = AsyncResult(task_id)
-    if callback.task_id and callback.ready():
-        if get_results:
-            gets = callback.get()
-            for res in gets:
-                results[res[0]] = res[1]
+    if callback.task_id and callback.ready() and get_results:
+        gets = callback.get()
+        for res in gets:
+            results[res[0]] = res[1]
     else:
         log.debug("Task is not yet ready.")
     return ProbeTaskResult(

--- a/frontend/js/internetnl.probe.js
+++ b/frontend/js/internetnl.probe.js
@@ -38,10 +38,11 @@ function parseStatuses(json) {
     var retry = false;
     for (var i=0; i<json.length; i++) {
         var obj = json[i];
-        if (obj.done == true) {
+        if (obj.done === true && obj.success === true) {
             showResults(obj.name, obj);
-        }
-        else {
+        } else if (obj.done === true && obj.success === false) {
+            showError(obj.name);
+        } else {
             retry = true;
         }
     }

--- a/frontend/js/internetnl.probe.js
+++ b/frontend/js/internetnl.probe.js
@@ -38,10 +38,9 @@ function parseStatuses(json) {
     var retry = false;
     for (var i=0; i<json.length; i++) {
         var obj = json[i];
-        if (obj.done === true && obj.success === true) {
-            showResults(obj.name, obj);
-        } else if (obj.done === true && obj.success === false) {
-            showError(obj.name);
+        if (obj.done === true) {
+            if (obj.success === true) { showResults(obj.name, obj); }
+            else { showError(obj.name); }
         } else {
             retry = true;
         }

--- a/interface/views/shared.py
+++ b/interface/views/shared.py
@@ -96,10 +96,9 @@ def proberesults(request, probe, dname):
     url = dname.lower()
     task_result = probe.raw_results(url, get_client_ip(request))
     if task_result.done:
-        results = probe.rated_results(url)
+        return probe.rated_results(url)
     else:
-        results = dict(done=False)
-    return results
+        return dict(done=False)
 
 
 def probestatus(request, probe, dname) -> ProbeTaskResult:
@@ -118,12 +117,13 @@ def probestatuses(request, dname, probes):
     statuses = []
     for probe in probes:
         task_result = probestatus(request, probe, dname)
-        status = {
-            "name": probe.name,
-            "done": task_result.done,
-            "success": task_result.success,
-        }
-        statuses.append(status)
+        statuses.append(
+            {
+                "name": probe.name,
+                "done": task_result.done,
+                "success": task_result.success,
+            }
+        )
     return statuses
 
 
@@ -269,7 +269,7 @@ def get_hof_manual(manual):
 
 def get_retest_time(report):
     time_delta = timezone.make_aware(datetime.now()) - report.timestamp
-    return int(max(0, 1 - time_delta.total_seconds()))
+    return int(max(0, settings.CACHE_TTL - time_delta.total_seconds()))
 
 
 def ub_resolve_with_timeout(qname, qtype, rr_class, timeout):


### PR DESCRIPTION
Before this change, the only check was whether a test was complete,
not whether it was at all successful. After redirect to the result
page, we then presented the most recent result for each probe,
which could silently return results from the distant past.

There may still be some cases where test error handling is not optimal,
but those should be loud, which means #770 will notify us.