### PR TITLE
Create frontend CSS/JS target directories if they don't exist

### DIFF
--- a/bin/frontend.py
+++ b/bin/frontend.py
@@ -27,6 +27,10 @@ def build_js(args=None):
     print("-"*20)
     print("Building JS files.")
     unique = uuid().hex
+    try:
+        os.mkdir(DJANGO_STATIC_JS_FOLDER)
+    except FileExistsError:
+        pass
     for root, dirs, files in os.walk(FRONTEND_JS_FOLDER):
         for filename in files:
             if filename.endswith(".js"):
@@ -56,6 +60,10 @@ def build_css(args=None):
     """
     print("-"*20)
     print("Building CSS files.")
+    try:
+        os.mkdir(DJANGO_STATIC_CSS_FOLDER)
+    except FileExistsError:
+        pass
     for root, dirs, files in os.walk(FRONTEND_CSS_FOLDER):
         for filename in files:
             if filename.endswith(".css"):


### PR DESCRIPTION
After the clean up in 329d9dea5b37f8432f1c00fdfdaf4a929c504ae9,
the target CSS directory does not always exist, which would
cause an error.
