### PR TITLE
Fix #774 - Make security.txt tech table (and potentially others) translatable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.7
+
+This release has API version 2.3.0, The `securitytxt_errors` and
+`securitytxt_recommendations` types were changed, and the
+`record_org_domain` was added for DMARC.
+
 ## 1.6.3
 
 - Fixed an issue in the HTTPS client code that caused DMARC records to not be detected, due to a missing

--- a/checks/categories.py
+++ b/checks/categories.py
@@ -127,6 +127,7 @@ class Subtest:
             )
         return rooted_tech_data
 
+
 # --- Categories
 #
 class WebIpv6(Category):

--- a/checks/categories.py
+++ b/checks/categories.py
@@ -2320,6 +2320,8 @@ class WebAppsecprivHttpReferrerPolicy(Subtest):
 
 
 class WebAppsecprivSecuritytxt(Subtest):
+    table_translation_root = "detail tech data http-securitytxt"
+
     def __init__(self):
         super().__init__(
             name="http_securitytxt",
@@ -2329,19 +2331,28 @@ class WebAppsecprivSecuritytxt(Subtest):
             worst_status=scoring.WEB_APPSECPRIV_SECURITYTXT_WORST_STATUS,
             full_score=scoring.WEB_APPSECPRIV_SECURITYTXT_GOOD,
             model_score_field="securitytxt_score",
+            init_tech_type="table_translatable",
         )
 
     def result_good(self, tech_data):
         self._status(STATUS_SUCCESS)
         self.verdict = "detail web appsecpriv http-securitytxt verdict good"
-        self.tech_data = tech_data
+        self.tech_data = self._add_table_translation_root(tech_data)
 
     def result_bad(self, tech_data):
         self._status(STATUS_NOTICE)
         self.verdict = "detail web appsecpriv http-securitytxt verdict bad"
-        self.tech_data = tech_data or ""
+        self.tech_data = self._add_table_translation_root(tech_data) or ""
 
     def result_recommendations(self, tech_data):
         self._status(STATUS_INFO)
         self.verdict = "detail web appsecpriv http-securitytxt verdict recommendations"
-        self.tech_data = tech_data or ""
+        self.tech_data = self._add_table_translation_root(tech_data) or ""
+
+    def _add_table_translation_root(self, tech_data):
+        rooted_tech_data = []
+        for data in tech_data:
+            rooted_tech_data.append(
+                {"message": f"{self.table_translation_root} {data['message']}", "context": data.get("context", {})}
+            )
+        return rooted_tech_data

--- a/checks/categories.py
+++ b/checks/categories.py
@@ -73,6 +73,7 @@ class Subtest:
         init_verdict="detail verdict not-tested",
         init_tech_type="table",
         init_tech_data="detail tech data not-tested",
+        tech_data_translation_root="",
     ):
         self.name = name
         self.label = label
@@ -85,6 +86,7 @@ class Subtest:
         self.verdict = init_verdict
         self.tech_type = init_tech_type
         self.tech_data = init_tech_data
+        self.tech_data_translation_root = tech_data_translation_root
 
     def _status(self, status, override=False):
         """
@@ -117,6 +119,13 @@ class Subtest:
             "tech_data": self.tech_data,
         }
 
+    def add_tech_data_translation_root(self, tech_data):
+        rooted_tech_data = []
+        for data in tech_data:
+            rooted_tech_data.append(
+                {"msgid": f"{self.tech_data_translation_root} {data['msgid']}", "context": data.get("context", {})}
+            )
+        return rooted_tech_data
 
 # --- Categories
 #
@@ -2320,8 +2329,6 @@ class WebAppsecprivHttpReferrerPolicy(Subtest):
 
 
 class WebAppsecprivSecuritytxt(Subtest):
-    table_translation_root = "detail tech data http-securitytxt"
-
     def __init__(self):
         super().__init__(
             name="http_securitytxt",
@@ -2332,27 +2339,20 @@ class WebAppsecprivSecuritytxt(Subtest):
             full_score=scoring.WEB_APPSECPRIV_SECURITYTXT_GOOD,
             model_score_field="securitytxt_score",
             init_tech_type="table_translatable",
+            tech_data_translation_root="detail tech data http-securitytxt",
         )
 
     def result_good(self, tech_data):
         self._status(STATUS_SUCCESS)
         self.verdict = "detail web appsecpriv http-securitytxt verdict good"
-        self.tech_data = self._add_table_translation_root(tech_data)
+        self.tech_data = self.add_tech_data_translation_root(tech_data)
 
     def result_bad(self, tech_data):
         self._status(STATUS_NOTICE)
         self.verdict = "detail web appsecpriv http-securitytxt verdict bad"
-        self.tech_data = self._add_table_translation_root(tech_data) or ""
+        self.tech_data = self.add_tech_data_translation_root(tech_data) or ""
 
     def result_recommendations(self, tech_data):
         self._status(STATUS_INFO)
         self.verdict = "detail web appsecpriv http-securitytxt verdict recommendations"
-        self.tech_data = self._add_table_translation_root(tech_data) or ""
-
-    def _add_table_translation_root(self, tech_data):
-        rooted_tech_data = []
-        for data in tech_data:
-            rooted_tech_data.append(
-                {"message": f"{self.table_translation_root} {data['message']}", "context": data.get("context", {})}
-            )
-        return rooted_tech_data
+        self.tech_data = self.add_tech_data_translation_root(tech_data) or ""

--- a/checks/tasks/appsecpriv.py
+++ b/checks/tasks/appsecpriv.py
@@ -158,9 +158,19 @@ def build_report(model, category):
             category.subtests["http_x_content_type"].result_bad(model.x_content_type_options_values)
 
         if model.securitytxt_enabled:
-            default_message = [f"Retrieved security.txt from {model.securitytxt_found_host}."]
+            default_message = [
+                {
+                    "message": "retrieved-from",
+                    "context": {"hostname": model.securitytxt_found_host},
+                }
+            ]
         else:
-            default_message = [f"Requested security.txt from {model.securitytxt_found_host}."]
+            default_message = [
+                {
+                    "message": "requested-from",
+                    "context": {"hostname": model.securitytxt_found_host},
+                }
+            ]
 
         if model.securitytxt_errors or not model.securitytxt_enabled:
             category.subtests["http_securitytxt"].result_bad(

--- a/checks/tasks/appsecpriv.py
+++ b/checks/tasks/appsecpriv.py
@@ -160,14 +160,14 @@ def build_report(model, category):
         if model.securitytxt_enabled:
             default_message = [
                 {
-                    "message": "retrieved-from",
+                    "msgid": "retrieved-from",
                     "context": {"hostname": model.securitytxt_found_host},
                 }
             ]
         else:
             default_message = [
                 {
-                    "message": "requested-from",
+                    "msgid": "requested-from",
                     "context": {"hostname": model.securitytxt_found_host},
                 }
             ]

--- a/checks/tasks/securitytxt.py
+++ b/checks/tasks/securitytxt.py
@@ -3,7 +3,7 @@
 import http.client
 from cgi import parse_header
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Dict
 
 import sectxt
 
@@ -22,7 +22,7 @@ class SecuritytxtRetrieveResult:
     content: Optional[str]
     url: str
     found_host: str
-    errors: List[str]
+    errors: List[Dict[str, str]]
 
 
 def securitytxt_check(af_ip_pair, domain, task):
@@ -71,7 +71,7 @@ def _retrieve_securitytxt(af_ip_pair, domain: str, task) -> SecuritytxtRetrieveR
             content=None,
             url=f"https://{domain}{path}",
             found_host=found_host,
-            errors=["Error: Content must be utf-8 encoded."],
+            errors=[{"message": "utf8"}],
         )
     return _evaluate_response(status, content_type, domain, path, content, found_host)
 
@@ -86,27 +86,33 @@ def _evaluate_response(
         charset = params.get("charset", "utf-8").lower()
 
     if not status or status == 404:
-        errors.append("Error: security.txt could not be located.")
+        errors.append(
+            {
+                "message": "no_security_txt_404",
+            }
+        )
     elif status != 200:
-        errors.append(f"Error: security.txt could not be located (unexpected HTTP response code {status}).")
+        errors.append(
+            {
+                "message": "no_security_txt_other",
+                "context": {"status_code": status},
+            }
+        )
     elif not content_type:
-        errors.append("Error: HTTP Content-Type header must be sent.")
+        errors.append({"message": "no_content_type"})
         # In case of missing or not text/plain type, there is a fair chance this
         # is an HTML page, for which there is no point to try to parse the content
         # as it will flood the user with useless errors. Therefore, we ignore content
         # in this scenario.
         content = None
     elif media_type.lower() != "text/plain":
-        errors.append("Error: Media type in Content-Type header must be 'text/plain'.")
+        errors.append({"message": "invalid_media"})
         content = None
     elif charset != "utf-8" and charset != "csutf8":
-        errors.append("Error: Charset parameter in Content-Type header must be 'utf-8' if present.")
+        errors.append({"message": "invalid_charset"})
 
     if status == 200 and path != SECURITYTXT_EXPECTED_PATH:
-        errors.append(
-            "Error: security.txt was located on the top-level path (legacy place), "
-            "but must be placed under the '/.well-known/' path."
-        )
+        errors.append({"message": "location"})
 
     return SecuritytxtRetrieveResult(
         found=status == 200,
@@ -118,11 +124,8 @@ def _evaluate_response(
 
 
 def _evaluate_securitytxt(result: SecuritytxtRetrieveResult):
-    def parser_format(message_type, parser_messages):
-        return [
-            message_type + ": " + m["message"] + (f" (line {m['line']})" if m.get("line") else "")
-            for m in parser_messages
-        ]
+    def parser_format(parser_messages):
+        return [{"message": f"{m['code']}", "context": {"line_no": m.get("line")}} for m in parser_messages]
 
     if not result.found or not result.content:
         return {
@@ -136,7 +139,7 @@ def _evaluate_securitytxt(result: SecuritytxtRetrieveResult):
     # URL intentionally not passed as Canonical testing is out of scope at this time
     parser = sectxt.Parser(result.content)
 
-    errors = result.errors + parser_format("Error", parser.errors)
+    errors = result.errors + parser_format(parser.errors)
     score = scoring.WEB_APPSECPRIV_SECURITYTXT_BAD if errors else scoring.WEB_APPSECPRIV_SECURITYTXT_GOOD
 
     return {
@@ -144,5 +147,5 @@ def _evaluate_securitytxt(result: SecuritytxtRetrieveResult):
         "securitytxt_score": score,
         "securitytxt_found_host": result.found_host,
         "securitytxt_errors": errors,
-        "securitytxt_recommendations": parser_format("Recommendation", parser.recommendations),
+        "securitytxt_recommendations": parser_format(parser.recommendations),
     }

--- a/checks/tasks/securitytxt.py
+++ b/checks/tasks/securitytxt.py
@@ -71,7 +71,7 @@ def _retrieve_securitytxt(af_ip_pair, domain: str, task) -> SecuritytxtRetrieveR
             content=None,
             url=f"https://{domain}{path}",
             found_host=found_host,
-            errors=[{"message": "utf8"}],
+            errors=[{"msgid": "utf8"}],
         )
     return _evaluate_response(status, content_type, domain, path, content, found_host)
 
@@ -88,31 +88,31 @@ def _evaluate_response(
     if not status or status == 404:
         errors.append(
             {
-                "message": "no_security_txt_404",
+                "msgid": "no_security_txt_404",
             }
         )
     elif status != 200:
         errors.append(
             {
-                "message": "no_security_txt_other",
+                "msgid": "no_security_txt_other",
                 "context": {"status_code": status},
             }
         )
     elif not content_type:
-        errors.append({"message": "no_content_type"})
+        errors.append({"msgid": "no_content_type"})
         # In case of missing or not text/plain type, there is a fair chance this
         # is an HTML page, for which there is no point to try to parse the content
         # as it will flood the user with useless errors. Therefore, we ignore content
         # in this scenario.
         content = None
     elif media_type.lower() != "text/plain":
-        errors.append({"message": "invalid_media"})
+        errors.append({"msgid": "invalid_media"})
         content = None
     elif charset != "utf-8" and charset != "csutf8":
-        errors.append({"message": "invalid_charset"})
+        errors.append({"msgid": "invalid_charset"})
 
     if status == 200 and path != SECURITYTXT_EXPECTED_PATH:
-        errors.append({"message": "location"})
+        errors.append({"msgid": "location"})
 
     return SecuritytxtRetrieveResult(
         found=status == 200,
@@ -125,7 +125,7 @@ def _evaluate_response(
 
 def _evaluate_securitytxt(result: SecuritytxtRetrieveResult):
     def parser_format(parser_messages):
-        return [{"message": f"{m['code']}", "context": {"line_no": m.get("line")}} for m in parser_messages]
+        return [{"msgid": f"{m['code']}", "context": {"line_no": m.get("line")}} for m in parser_messages]
 
     if not result.found or not result.content:
         return {

--- a/checks/test/test_securitytxt.py
+++ b/checks/test/test_securitytxt.py
@@ -46,7 +46,7 @@ def test_evaluate_response():
         content=sectxt_content,
         url="https://example.com/.well-known/security.txt",
         found_host="example.nl",
-        errors=[{"message": "no_security_txt_404"}],
+        errors=[{"msgid": "no_security_txt_404"}],
     )
 
     result = _evaluate_with_valid_defaults(
@@ -57,7 +57,7 @@ def test_evaluate_response():
         content=sectxt_content,
         url="https://example.com/.well-known/security.txt",
         found_host="example.nl",
-        errors=[{"message": "no_security_txt_other", "context": {"status_code": 500}}],
+        errors=[{"msgid": "no_security_txt_other", "context": {"status_code": 500}}],
     )
 
     result = _evaluate_with_valid_defaults(
@@ -68,7 +68,7 @@ def test_evaluate_response():
         content=None,
         url="https://example.com/.well-known/security.txt",
         found_host="example.nl",
-        errors=[{"message": "no_content_type"}],
+        errors=[{"msgid": "no_content_type"}],
     )
 
     result = _evaluate_with_valid_defaults(
@@ -79,7 +79,7 @@ def test_evaluate_response():
         content=None,
         url="https://example.com/.well-known/security.txt",
         found_host="example.nl",
-        errors=[{"message": "invalid_media"}],
+        errors=[{"msgid": "invalid_media"}],
     )
 
     result = _evaluate_with_valid_defaults(
@@ -90,7 +90,7 @@ def test_evaluate_response():
         content=None,
         url="https://example.com/.well-known/security.txt",
         found_host="example.nl",
-        errors=[{"message": "invalid_media"}],
+        errors=[{"msgid": "invalid_media"}],
     )
 
     result = _evaluate_with_valid_defaults(
@@ -101,7 +101,7 @@ def test_evaluate_response():
         content=sectxt_content,
         url="https://example.com/.well-known/security.txt",
         found_host="example.nl",
-        errors=[{"message": "invalid_charset"}],
+        errors=[{"msgid": "invalid_charset"}],
     )
 
     result = _evaluate_with_valid_defaults(
@@ -112,7 +112,7 @@ def test_evaluate_response():
         content=sectxt_content,
         url="https://example.com/security.txt",
         found_host="example.nl",
-        errors=[{"message": "location"}],
+        errors=[{"msgid": "location"}],
     )
 
 
@@ -122,13 +122,13 @@ def test_evaluate_securitytxt():
         content="",
         url="https://example.com/security.txt",
         found_host="host",
-        errors=[{"message": "example"}],
+        errors=[{"msgid": "example"}],
     )
     assert _evaluate_securitytxt(result) == {
         "securitytxt_enabled": False,
         "securitytxt_score": scoring.WEB_APPSECPRIV_SECURITYTXT_BAD,
         "securitytxt_found_host": "host",
-        "securitytxt_errors": [{"message": "example"}],
+        "securitytxt_errors": [{"msgid": "example"}],
         "securitytxt_recommendations": [],
     }
 
@@ -144,11 +144,11 @@ def test_evaluate_securitytxt():
         "securitytxt_score": scoring.WEB_APPSECPRIV_SECURITYTXT_BAD,
         "securitytxt_found_host": "host",
         "securitytxt_errors": [
-            {"message": "invalid_line", "context": {"line_no": 1}},
-            {"message": "no_expire", "context": {"line_no": None}},
-            {"message": "no_contact", "context": {"line_no": None}},
+            {"msgid": "invalid_line", "context": {"line_no": 1}},
+            {"msgid": "no_expire", "context": {"line_no": None}},
+            {"msgid": "no_contact", "context": {"line_no": None}},
         ],
-        "securitytxt_recommendations": [{"message": "not_signed", "context": {"line_no": None}}],
+        "securitytxt_recommendations": [{"msgid": "not_signed", "context": {"line_no": None}}],
     }
 
     result = SecuritytxtRetrieveResult(
@@ -156,17 +156,17 @@ def test_evaluate_securitytxt():
         content="Expires: 2050-09-01T00:00:00.000Z\nContact: mailto:security@example.com",
         url="https://example.com/security.txt",
         found_host="host",
-        errors=[{"message": "example"}],
+        errors=[{"msgid": "example"}],
     )
     assert _evaluate_securitytxt(result) == {
         "securitytxt_enabled": True,
         "securitytxt_score": scoring.WEB_APPSECPRIV_SECURITYTXT_BAD,
         "securitytxt_found_host": "host",
-        "securitytxt_errors": [{"message": "example"}],
+        "securitytxt_errors": [{"msgid": "example"}],
         "securitytxt_recommendations": [
-            {"message": "long_expiry", "context": {"line_no": 1}},
-            {"message": "no_encryption", "context": {"line_no": None}},
-            {"message": "not_signed", "context": {"line_no": None}},
+            {"msgid": "long_expiry", "context": {"line_no": 1}},
+            {"msgid": "no_encryption", "context": {"line_no": None}},
+            {"msgid": "not_signed", "context": {"line_no": None}},
         ],
     }
 
@@ -183,8 +183,8 @@ def test_evaluate_securitytxt():
         "securitytxt_found_host": "host",
         "securitytxt_errors": [],
         "securitytxt_recommendations": [
-            {"message": "long_expiry", "context": {"line_no": 1}},
-            {"message": "no_encryption", "context": {"line_no": None}},
-            {"message": "not_signed", "context": {"line_no": None}},
+            {"msgid": "long_expiry", "context": {"line_no": 1}},
+            {"msgid": "no_encryption", "context": {"line_no": None}},
+            {"msgid": "not_signed", "context": {"line_no": None}},
         ],
     }

--- a/checks/test/test_securitytxt.py
+++ b/checks/test/test_securitytxt.py
@@ -146,6 +146,7 @@ def test_evaluate_securitytxt():
         "securitytxt_errors": [
             {"msgid": "invalid_line", "context": {"line_no": 1}},
             {"msgid": "no_expire", "context": {"line_no": None}},
+            {"msgid": "no_line_separators", "context": {"line_no": None}},
             {"msgid": "no_contact", "context": {"line_no": None}},
         ],
         "securitytxt_recommendations": [{"msgid": "not_signed", "context": {"line_no": None}}],
@@ -153,7 +154,7 @@ def test_evaluate_securitytxt():
 
     result = SecuritytxtRetrieveResult(
         found=True,
-        content="Expires: 2050-09-01T00:00:00.000Z\nContact: mailto:security@example.com",
+        content="Expires: 2050-09-01T00:00:00.000Z\nContact: mailto:security@example.com\n",
         url="https://example.com/security.txt",
         found_host="host",
         errors=[{"msgid": "example"}],
@@ -172,7 +173,7 @@ def test_evaluate_securitytxt():
 
     result = SecuritytxtRetrieveResult(
         found=True,
-        content="Expires: 2050-09-01T00:00:00.000Z\nContact: mailto:security@example.com",
+        content="Expires: 2050-09-01T00:00:00.000Z\nContact: mailto:security@example.com\n",
         url="https://example.com/security.txt",
         found_host="host",
         errors=[],

--- a/checks/test/test_securitytxt.py
+++ b/checks/test/test_securitytxt.py
@@ -46,7 +46,7 @@ def test_evaluate_response():
         content=sectxt_content,
         url="https://example.com/.well-known/security.txt",
         found_host="example.nl",
-        errors=["Error: security.txt could not be located."],
+        errors=[{"message": "no_security_txt_404"}],
     )
 
     result = _evaluate_with_valid_defaults(
@@ -57,7 +57,7 @@ def test_evaluate_response():
         content=sectxt_content,
         url="https://example.com/.well-known/security.txt",
         found_host="example.nl",
-        errors=["Error: security.txt could not be located (unexpected HTTP response code 500)."],
+        errors=[{"message": "no_security_txt_other", "context": {"status_code": 500}}],
     )
 
     result = _evaluate_with_valid_defaults(
@@ -68,7 +68,7 @@ def test_evaluate_response():
         content=None,
         url="https://example.com/.well-known/security.txt",
         found_host="example.nl",
-        errors=["Error: HTTP Content-Type header must be sent."],
+        errors=[{"message": "no_content_type"}],
     )
 
     result = _evaluate_with_valid_defaults(
@@ -79,7 +79,7 @@ def test_evaluate_response():
         content=None,
         url="https://example.com/.well-known/security.txt",
         found_host="example.nl",
-        errors=["Error: Media type in Content-Type header must be 'text/plain'."],
+        errors=[{"message": "invalid_media"}],
     )
 
     result = _evaluate_with_valid_defaults(
@@ -90,7 +90,7 @@ def test_evaluate_response():
         content=None,
         url="https://example.com/.well-known/security.txt",
         found_host="example.nl",
-        errors=["Error: Media type in Content-Type header must be 'text/plain'."],
+        errors=[{"message": "invalid_media"}],
     )
 
     result = _evaluate_with_valid_defaults(
@@ -101,7 +101,7 @@ def test_evaluate_response():
         content=sectxt_content,
         url="https://example.com/.well-known/security.txt",
         found_host="example.nl",
-        errors=["Error: Charset parameter in Content-Type header must be 'utf-8' if present."],
+        errors=[{"message": "invalid_charset"}],
     )
 
     result = _evaluate_with_valid_defaults(
@@ -112,10 +112,7 @@ def test_evaluate_response():
         content=sectxt_content,
         url="https://example.com/security.txt",
         found_host="example.nl",
-        errors=[
-            "Error: security.txt was located on the top-level path (legacy place), "
-            "but must be placed under the '/.well-known/' path."
-        ],
+        errors=[{"message": "location"}],
     )
 
 
@@ -125,13 +122,13 @@ def test_evaluate_securitytxt():
         content="",
         url="https://example.com/security.txt",
         found_host="host",
-        errors=["Error: network error"],
+        errors=[{"message": "example"}],
     )
     assert _evaluate_securitytxt(result) == {
         "securitytxt_enabled": False,
         "securitytxt_score": scoring.WEB_APPSECPRIV_SECURITYTXT_BAD,
         "securitytxt_found_host": "host",
-        "securitytxt_errors": ["Error: network error"],
+        "securitytxt_errors": [{"message": "example"}],
         "securitytxt_recommendations": [],
     }
 
@@ -147,11 +144,11 @@ def test_evaluate_securitytxt():
         "securitytxt_score": scoring.WEB_APPSECPRIV_SECURITYTXT_BAD,
         "securitytxt_found_host": "host",
         "securitytxt_errors": [
-            "Error: Line must contain a field name and value, unless the line is blank or contains a comment. (line 1)",
-            "Error: 'Expires' field must be present.",
-            "Error: 'Contact' field must appear at least once.",
+            {"message": "invalid_line", "context": {"line_no": 1}},
+            {"message": "no_expire", "context": {"line_no": None}},
+            {"message": "no_contact", "context": {"line_no": None}},
         ],
-        "securitytxt_recommendations": ["Recommendation: security.txt should be digitally signed."],
+        "securitytxt_recommendations": [{"message": "not_signed", "context": {"line_no": None}}],
     }
 
     result = SecuritytxtRetrieveResult(
@@ -159,17 +156,17 @@ def test_evaluate_securitytxt():
         content="Expires: 2050-09-01T00:00:00.000Z\nContact: mailto:security@example.com",
         url="https://example.com/security.txt",
         found_host="host",
-        errors=["Error: content-type error"],
+        errors=[{"message": "example"}],
     )
     assert _evaluate_securitytxt(result) == {
         "securitytxt_enabled": True,
         "securitytxt_score": scoring.WEB_APPSECPRIV_SECURITYTXT_BAD,
         "securitytxt_found_host": "host",
-        "securitytxt_errors": ["Error: content-type error"],
+        "securitytxt_errors": [{"message": "example"}],
         "securitytxt_recommendations": [
-            "Recommendation: Date and time in 'Expires' field should be less than a year into the future. (line 1)",
-            "Recommendation: 'Encryption' field should be present when 'Contact' field contains an email address.",
-            "Recommendation: security.txt should be digitally signed.",
+            {"message": "long_expiry", "context": {"line_no": 1}},
+            {"message": "no_encryption", "context": {"line_no": None}},
+            {"message": "not_signed", "context": {"line_no": None}},
         ],
     }
 
@@ -186,8 +183,8 @@ def test_evaluate_securitytxt():
         "securitytxt_found_host": "host",
         "securitytxt_errors": [],
         "securitytxt_recommendations": [
-            "Recommendation: Date and time in 'Expires' field should be less than a year into the future. (line 1)",
-            "Recommendation: 'Encryption' field should be present when 'Contact' field contains an email address.",
-            "Recommendation: security.txt should be digitally signed.",
+            {"message": "long_expiry", "context": {"line_no": 1}},
+            {"message": "no_encryption", "context": {"line_no": None}},
+            {"message": "not_signed", "context": {"line_no": None}},
         ],
     }

--- a/interface/batch/openapi.yaml
+++ b/interface/batch/openapi.yaml
@@ -825,13 +825,29 @@ components:
           description: >
             Errors found while parsing an RFC9116 security.txt file
           items:
-            type: string
+            type: object
+            properties:
+              message:
+                type: string
+                description: message code (largely matches https://github.com/DigitalTrustCenter/sectxt/blob/main/README.md)
+              context:
+                type: object
+                additionalProperties: true
+                description: additional context for the message, e.g. line number
         securitytxt_recommendations:
           type: array
           description: >
             Recommendations found while parsing an RFC9116 security.txt file
           items:
-            type: string
+            type: object
+            properties:
+              message:
+                type: string
+                description: message code (largely matches https://github.com/DigitalTrustCenter/sectxt/blob/main/README.md)
+              context:
+                type: object
+                additionalProperties: true
+                description: additional context for the message, e.g. line number
         securitytxt_found_host:
           type: string
           description: The host from which the security.txt was retrieved, after potential redirects

--- a/interface/batch/openapi.yaml
+++ b/interface/batch/openapi.yaml
@@ -827,9 +827,9 @@ components:
           items:
             type: object
             properties:
-              message:
+              msgid:
                 type: string
-                description: message code (largely matches https://github.com/DigitalTrustCenter/sectxt/blob/main/README.md)
+                description: message id (largely matches https://github.com/DigitalTrustCenter/sectxt/blob/main/README.md)
               context:
                 type: object
                 additionalProperties: true
@@ -841,9 +841,9 @@ components:
           items:
             type: object
             properties:
-              message:
+              msgid:
                 type: string
-                description: message code (largely matches https://github.com/DigitalTrustCenter/sectxt/blob/main/README.md)
+                description: message id (largely matches https://github.com/DigitalTrustCenter/sectxt/blob/main/README.md)
               context:
                 type: object
                 additionalProperties: true

--- a/interface/batch/openapi.yaml
+++ b/interface/batch/openapi.yaml
@@ -823,31 +823,17 @@ components:
         securitytxt_errors:
           type: array
           description: >
-            Errors found while parsing an RFC9116 security.txt file
+            Errors found while parsing an RFC9116 security.txt file.
+            Message IDs generally match https://github.com/DigitalTrustCenter/sectxt/blob/main/README.md
           items:
-            type: object
-            properties:
-              msgid:
-                type: string
-                description: message id (largely matches https://github.com/DigitalTrustCenter/sectxt/blob/main/README.md)
-              context:
-                type: object
-                additionalProperties: true
-                description: additional context for the message, e.g. line number
+            $ref: '#/components/schemas/TechnicalMessagesWithContext'
         securitytxt_recommendations:
           type: array
           description: >
             Recommendations found while parsing an RFC9116 security.txt file
+            Message IDs generally match https://github.com/DigitalTrustCenter/sectxt/blob/main/README.md
           items:
-            type: object
-            properties:
-              msgid:
-                type: string
-                description: message id (largely matches https://github.com/DigitalTrustCenter/sectxt/blob/main/README.md)
-              context:
-                type: object
-                additionalProperties: true
-                description: additional context for the message, e.g. line number
+            $ref: '#/components/schemas/TechnicalMessagesWithContext'
         securitytxt_found_host:
           type: string
           description: The host from which the security.txt was retrieved, after potential redirects
@@ -1151,6 +1137,17 @@ components:
           allOf:
             - $ref: '#/components/schemas/TechnicalSharedDetails'
             - $ref: '#/components/schemas/TechnicalReceivingMailServerDetails'
+
+    TechnicalMessagesWithContext:
+      type: object
+      properties:
+        msgid:
+          type: string
+          description: message id
+        context:
+          type: object
+          additionalProperties: true
+          description: additional context for the message, e.g. line numbers of errors
 
     DomainStatus:
       type: string

--- a/interface/templates/details-test-item.html
+++ b/interface/templates/details-test-item.html
@@ -21,8 +21,8 @@
         <h4>
           {% include "string.html" with name="results tech-details label" %}
         </h4>
-          {% if testitem.tech_type == 'table' or testitem.tech_type == 'table_multi_col' %}
-            {% render_details_table testitem.tech_string testitem.tech_data %}
+          {% if testitem.tech_type == 'table' or testitem.tech_type == 'table_multi_col' or testitem.tech_type == 'table_translatable' %}
+            {% render_details_table tech_type=testitem.tech_type table_headers=testitem.tech_string table_content=testitem.tech_data %}
           {% endif %}
         {% endif %}
         <h4>

--- a/interface/templatetags/translate.py
+++ b/interface/templatetags/translate.py
@@ -107,8 +107,7 @@ def render_details_table(tech_type, table_headers, table_content):
                         value = _("results empty-argument-alt-text")
                     elif tech_type == "table_translatable":
                         if type(value) == dict:
-                            # TODO: we need to be sure about the naming of message/context
-                            value = _(value["message"]).format(**value.get("context", {}))
+                            value = _(value["msgid"]).format(**value.get("context", {}))
                     elif value in [
                         "detail tech data yes",
                         "detail tech data no",

--- a/interface/templatetags/translate.py
+++ b/interface/templatetags/translate.py
@@ -72,22 +72,22 @@ def maxlength(adjustment, *args):
 
 
 @register.inclusion_tag("details-table.html")
-def render_details_table(headers, arguments):
+def render_details_table(tech_type, table_headers, table_content):
     """
     Figure out the table's header and content and render them based on the
     given template.
 
     """
-    headers = _(headers)
+    headers = _(table_headers)
     headers = headers.split("|")
 
     table_length = len(headers)
     final_rows = []
     max_columns = 0
-    for row_argument in arguments:
+    for table_row in table_content:
         row_generator = []
         # Create the row_generator for this row(s).
-        for i, row_attribute in enumerate(row_argument):
+        for i, row_attribute in enumerate(table_row):
             if i >= table_length:
                 break
 
@@ -105,6 +105,10 @@ def render_details_table(headers, arguments):
                     value = cell_deque.popleft()
                     if not value:
                         value = _("results empty-argument-alt-text")
+                    elif tech_type == "table_translatable":
+                        if type(value) == dict:
+                            # TODO: we need to be sure about the naming of message/context
+                            value = _(value["message"]).format(**value.get("context", {}))
                     elif value in [
                         "detail tech data yes",
                         "detail tech data no",

--- a/requirements.txt
+++ b/requirements.txt
@@ -155,7 +155,7 @@ requests==2.28.2
     #   sectxt
 rjsmin==1.2.1
     # via -r requirements.in
-sectxt==0.7
+sectxt==0.8
     # via -r requirements.in
 selenium==3.141.0
     # via -r requirements.in

--- a/translations/en/main.po
+++ b/translations/en/main.po
@@ -1767,6 +1767,96 @@ msgstr "sufficient"
 msgid "detail tech data yes"
 msgstr "yes"
 
+msgid "detail tech data http-securitytxt retrieved-from"
+msgstr "Retrieved security.txt from {hostname}."
+
+msgid "detail tech data http-securitytxt requested-from"
+msgstr "Requested security.txt from {hostname}."
+
+msgid "detail tech data http-securitytxt utf8"
+msgstr "Error: Content must be utf-8 encoded."
+
+msgid "detail tech data http-securitytxt no_security_txt_404"
+msgstr "Error: security.txt could not be located."
+
+msgid "detail tech data http-securitytxt no_security_txt_other"
+msgstr "Error: security.txt could not be located (unexpected HTTP response code {status_code})."
+
+msgid "detail tech data http-securitytxt no_content_type"
+msgstr "Error: HTTP Content-Type header must be sent."
+
+msgid "detail tech data http-securitytxt invalid_media"
+msgstr "Error: Media type in Content-Type header must be 'text/plain'."
+
+msgid "detail tech data http-securitytxt invalid_charset"
+msgstr "Error: Charset parameter in Content-Type header must be 'utf-8' if present."
+
+msgid "detail tech data http-securitytxt location"
+msgstr "Error: security.txt was located on the top-level path (legacy place), but must be placed under the '/.well-known/' path."
+
+msgid "detail tech data http-securitytxt no_expire"
+msgstr "Error: 'Expires' field must be present."
+
+msgid "detail tech data http-securitytxt multi_expire"
+msgstr "Error: 'Expires' field must not appear more than once."
+
+msgid "detail tech data http-securitytxt invalid_expiry"
+msgstr "Error: Date and time in 'Expires' field must be formatted according to ISO 8601 (line {line_no})."
+
+msgid "detail tech data http-securitytxt expired"
+msgstr "Error: Date and time in 'Expires' field must not be in the past (line {line_no})."
+
+msgid "detail tech data http-securitytxt no_contact"
+msgstr "Error: 'Contact' field must appear at least once."
+
+msgid "detail tech data http-securitytxt multi_lang"
+msgstr "Error: 'Preferred-Languages' field must not appear more than once."
+
+msgid "detail tech data http-securitytxt invalid_lang"
+msgstr "Error: Value in 'Preferred-Languages' field must match one or more language tags as defined in RFC5646, separated by commas (line {line_no})."
+
+msgid "detail tech data http-securitytxt no_uri"
+msgstr "Error: Field value must be a URI (e.g. beginning with 'mailto:') (line {line_no})."
+
+msgid "detail tech data http-securitytxt no_https"
+msgstr "Error: Web URI must begin with 'https://' (line {line_no})."
+
+msgid "detail tech data http-securitytxt prec_ws"
+msgstr "Error: There must be no whitespace before the field separator (colon) (line {line_no})."
+
+msgid "detail tech data http-securitytxt no_space"
+msgstr "Error: Field separator (colon) must be followed by a space (line {line_no})."
+
+msgid "detail tech data http-securitytxt empty_key"
+msgstr "Error: Field name must not be empty (line {line_no})."
+
+msgid "detail tech data http-securitytxt empty_value"
+msgstr "Error: Field value must not be empty (line {line_no})."
+
+msgid "detail tech data http-securitytxt invalid_line"
+msgstr "Error: Line must contain a field name and value, unless the line is blank or contains a comment (line {line_no})."
+
+msgid "detail tech data http-securitytxt no_line_separators"
+msgstr "Error: Every line must end with either a carriage return and line feed characters or just a line feed character."
+
+msgid "detail tech data http-securitytxt data_after_sig"
+msgstr "Error: Data exists after signature (line {line_no})."
+
+msgid "detail tech data http-securitytxt long_expiry"
+msgstr "Recommendation: Date and time in 'Expires' field should be less than a year into the future (line {line_no})."
+
+msgid "detail tech data http-securitytxt no_encryption"
+msgstr "Recommendation: 'Encryption' field should be present when 'Contact' field contains an email address."
+
+msgid "detail tech data http-securitytxt not_signed"
+msgstr "Recommendation: security.txt should be digitally signed."
+
+msgid "detail tech data http-securitytxt no_canonical"
+msgstr "Recommendation: 'Canonical' field should be present in a signed file."
+
+msgid "detail tech data http-securitytxt unknown_field"
+msgstr "Recommendation: security.txt contains an unknown field. Either this is a custom field which may not be widely supported, or there is a typo in a standardised field name (line {line_no})."
+
 msgid "detail verdict could-not-test"
 msgstr "Test error. Please try again later."
 

--- a/translations/nl/main.po
+++ b/translations/nl/main.po
@@ -1768,6 +1768,96 @@ msgstr "voldoende"
 msgid "detail tech data yes"
 msgstr "ja"
 
+msgid "detail tech data http-securitytxt retrieved-from"
+msgstr "Retrieved security.txt from {hostname}."
+
+msgid "detail tech data http-securitytxt requested-from"
+msgstr "Requested security.txt from {hostname}."
+
+msgid "detail tech data http-securitytxt utf8"
+msgstr "Error: Content must be utf-8 encoded."
+
+msgid "detail tech data http-securitytxt no_security_txt_404"
+msgstr "Error: security.txt could not be located."
+
+msgid "detail tech data http-securitytxt no_security_txt_other"
+msgstr "Error: security.txt could not be located (unexpected HTTP response code {status_code})."
+
+msgid "detail tech data http-securitytxt no_content_type"
+msgstr "Error: HTTP Content-Type header must be sent."
+
+msgid "detail tech data http-securitytxt invalid_media"
+msgstr "Error: Media type in Content-Type header must be 'text/plain'."
+
+msgid "detail tech data http-securitytxt invalid_charset"
+msgstr "Error: Charset parameter in Content-Type header must be 'utf-8' if present."
+
+msgid "detail tech data http-securitytxt location"
+msgstr "Error: security.txt was located on the top-level path (legacy place), but must be placed under the '/.well-known/' path."
+
+msgid "detail tech data http-securitytxt no_expire"
+msgstr "Error: 'Expires' field must be present."
+
+msgid "detail tech data http-securitytxt multi_expire"
+msgstr "Error: 'Expires' field must not appear more than once."
+
+msgid "detail tech data http-securitytxt invalid_expiry"
+msgstr "Error: Date and time in 'Expires' field must be formatted according to ISO 8601 (line {line_no})."
+
+msgid "detail tech data http-securitytxt expired"
+msgstr "Error: Date and time in 'Expires' field must not be in the past (line {line_no})."
+
+msgid "detail tech data http-securitytxt no_contact"
+msgstr "Error: 'Contact' field must appear at least once."
+
+msgid "detail tech data http-securitytxt multi_lang"
+msgstr "Error: 'Preferred-Languages' field must not appear more than once."
+
+msgid "detail tech data http-securitytxt invalid_lang"
+msgstr "Error: Value in 'Preferred-Languages' field must match one or more language tags as defined in RFC5646, separated by commas (line {line_no})."
+
+msgid "detail tech data http-securitytxt no_uri"
+msgstr "Error: Field value must be a URI (e.g. beginning with 'mailto:') (line {line_no})."
+
+msgid "detail tech data http-securitytxt no_https"
+msgstr "Error: Web URI must begin with 'https://' (line {line_no})."
+
+msgid "detail tech data http-securitytxt prec_ws"
+msgstr "Error: There must be no whitespace before the field separator (colon) (line {line_no})."
+
+msgid "detail tech data http-securitytxt no_space"
+msgstr "Error: Field separator (colon) must be followed by a space (line {line_no})."
+
+msgid "detail tech data http-securitytxt empty_key"
+msgstr "Error: Field name must not be empty (line {line_no})."
+
+msgid "detail tech data http-securitytxt empty_value"
+msgstr "Error: Field value must not be empty (line {line_no})."
+
+msgid "detail tech data http-securitytxt invalid_line"
+msgstr "Error: Line must contain a field name and value, unless the line is blank or contains a comment (line {line_no})."
+
+msgid "detail tech data http-securitytxt no_line_separators"
+msgstr "Error: Every line must end with either a carriage return and line feed characters or just a line feed character."
+
+msgid "detail tech data http-securitytxt data_after_sig"
+msgstr "Error: Data exists after signature (line {line_no})."
+
+msgid "detail tech data http-securitytxt long_expiry"
+msgstr "Recommendation: Date and time in 'Expires' field should be less than a year into the future (line {line_no})."
+
+msgid "detail tech data http-securitytxt no_encryption"
+msgstr "Recommendation: 'Encryption' field should be present when 'Contact' field contains an email address."
+
+msgid "detail tech data http-securitytxt not_signed"
+msgstr "Recommendation: security.txt should be digitally signed."
+
+msgid "detail tech data http-securitytxt no_canonical"
+msgstr "Recommendation: 'Canonical' field should be present in a signed file."
+
+msgid "detail tech data http-securitytxt unknown_field"
+msgstr "Recommendation: security.txt contains an unknown field. Either this is a custom field which may not be widely supported, or there is a typo in a standardised field name (line {line_no})."
+
 msgid "detail verdict could-not-test"
 msgstr "Testfout. Graag later opnieuw proberen."
 


### PR DESCRIPTION
This adds a new tech type: table_translatable. This allows the tech table to contain translation keys, with an optional context for formatting. For more background, see comments in #774.

Content PR: https://github.com/internetstandards/Internet.nl_content/pull/26

~~TODO: finalise the names "message" and "context" - they become part of the DB and API so it is really difficult to change them later for something better. Perhaps "message_code"? "msgid" to be consistent with translations? For context, "data" is an alternate, but probably weaker.~~