### PR TITLE
Fix public suffix list retrieval, which was causing DMARC detection to fail

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.6.3
+
+- Fixed an issue in the HTTPS client code that caused DMARC records to not be detected, due to a missing
+  public suffix list.
+
 ## 1.6.2
 
 - Fixed issues in the example configs regarding [celery concurrency](https://github.com/internetstandards/Internet.nl/issues/817)

--- a/checks/tasks/tls_connection.py
+++ b/checks/tasks/tls_connection.py
@@ -770,10 +770,12 @@ def http_get(url):
         rr.status_code = r.status
         if r.status == 200:
             ct_header = r.getheader("Content-Type", None)
+            encoding = "utf-8"
             if ct_header:
-                encoding = parse_header(ct_header)[1]["charset"]
-            else:
-                encoding = "utf-8"
+                try:
+                    encoding = parse_header(ct_header)[1]["charset"]
+                except (IndexError, KeyError):
+                    pass
             rr.text = r.read().decode(encoding)
         conn.close()
         result = rr


### PR DESCRIPTION
To be backported to a new 1.6.3 release.

Most likely, the API of publicsuffixlist.org changed slightly in the last few days, causing PSL retrieval to fail. When PSL retrieval fails, our DMARC test reports "no record found" on all tests.

This is a quick fix for several questionable things:
* Our DMARC test says "no record found" when the PSL can not be retrieved
* There is no exception logged or task failed, which means we would not detect this even with Sentry or other exception detection. The actual error was a KeyError on "charset", but this was being absorbed into a SoftTimeLimitExceeded.
* We use our own bespoke HTTPS client which apparently has some implementation issues which are not fixed in this PR. This is not needed in this case, as we can expect the PSL to support normal recent TLS, so we can use a standard HTTP client.

See also: https://github.com/internetstandards/Internet.nl/blob/v1.6.2/checks/tasks/mail.py#L543-L547