### PR TITLE
[1.6.x] Fix public suffix list retrieval, which was causing DMARC detection to fail

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.6.3
+
+- Fixed an issue in the HTTPS client code that caused DMARC records to not be detected, due to a missing
+  public suffix list.
+
 ## 1.6.2
 
 - Fixed issues in the example configs regarding [celery concurrency](https://github.com/internetstandards/Internet.nl/issues/817)

--- a/checks/tasks/tls_connection.py
+++ b/checks/tasks/tls_connection.py
@@ -777,10 +777,12 @@ def http_get(url):
         rr.status_code = r.status
         if r.status == 200:
             ct_header = r.getheader("Content-Type", None)
+            encoding = "utf-8"
             if ct_header:
-                encoding = parse_header(ct_header)[1]["charset"]
-            else:
-                encoding = "utf-8"
+                try:
+                    encoding = parse_header(ct_header)[1]["charset"]
+                except (IndexError, KeyError):
+                    pass
             rr.text = r.read().decode(encoding)
         conn.close()
         result = rr


### PR DESCRIPTION
Ref #855, #854

(cherry picked from commit 6d9070aab9f066184b117231876b49bf45832b78)