### PR TITLE
Fix #748 - Change level to info for null MX without A/AAAA

### DIFF
--- a/checks/categories.py
+++ b/checks/categories.py
@@ -575,9 +575,14 @@ class MailIpv6MxAaaa(Subtest):
         self.verdict = "detail mail ipv6 mx-AAAA verdict no-null-mx"
         self.tech_type = ""
 
-    def result_invalid_null_mx(self):
-        self._status(STATUS_NOTICE)
-        self.verdict = "detail mail ipv6 mx-AAAA verdict invalid-null-mx"
+    def result_null_mx_with_other_mx(self):
+        self._status(STATUS_NOTICE, override=True)
+        self.verdict = "detail mail ipv6 mx-AAAAA verdict null-mx-with-other-mx"
+        self.tech_type = ""
+
+    def result_null_mx_without_a_aaaa(self):
+        self._status(STATUS_INFO, override=True)
+        self.verdict = "detail mail ipv6 mx-AAAA verdict null-mx-without-a-aaaa"
         self.tech_type = ""
 
 
@@ -775,9 +780,15 @@ class MailDnssecMxExists(Subtest):
         self._status(STATUS_INFO)
         self.verdict = "detail mail dnssec mx-exists verdict no-null-mx"
 
-    def result_invalid_null_mx(self):
-        self._status(STATUS_NOTICE)
-        self.verdict = "detail mail dnssec mx-exists verdict invalid-null-mx"
+    def result_null_mx_with_other_mx(self):
+        self._status(STATUS_NOTICE, override=True)
+        self.verdict = "detail mail dnssec mx-exists verdict null-mx-with-other-mx"
+        self.tech_type = ""
+
+    def result_null_mx_without_a_aaaa(self):
+        self._status(STATUS_INFO, override=True)
+        self.verdict = "detail mail dnssec mx-exists verdict null-mx-without-a-aaaa"
+        self.tech_type = ""
 
     def result_good(self):
         self.was_tested()

--- a/checks/categories.py
+++ b/checks/categories.py
@@ -1463,9 +1463,14 @@ class MailTlsStarttlsExists(Subtest):
         self.verdict = "detail mail tls starttls-exists verdict no-null-mx"
         self.tech_type = ""
 
-    def result_invalid_null_mx(self):
+    def result_null_mx_with_other_mx(self):
         self._status(STATUS_NOTICE, override=True)
-        self.verdict = "detail mail tls starttls-exists verdict invalid-null-mx"
+        self.verdict = "detail mail tls starttls-exists verdict null-mx-with-other-mx"
+        self.tech_type = ""
+
+    def result_null_mx_without_a_aaaa(self):
+        self._status(STATUS_INFO, override=True)
+        self.verdict = "detail mail tls starttls-exists verdict null-mx-without-a-aaaa"
         self.tech_type = ""
 
 

--- a/checks/models.py
+++ b/checks/models.py
@@ -49,8 +49,9 @@ class MxStatus(LabelEnum):
     has_mx = 0
     no_mx = 1
     no_null_mx = 2
-    invalid_null_mx = 3
+    null_mx_with_other_mx = 3
     null_mx = 4
+    null_mx_without_a_aaaa = 5
 
 
 class DnssecStatus(Enum):

--- a/checks/probes.py
+++ b/checks/probes.py
@@ -359,9 +359,13 @@ class Probe:
                 return "no-null-mx"
             test_instance.result_null_mx_with_other_mx()
             if report[test_instance.name]["verdict"] == test_instance.verdict:
+                # test mailtls null-mx-with-other-mx description
+                # test mailtls null-mx-with-other-mx summary
                 return "null-mx-with-other-mx"
             test_instance.result_null_mx_without_a_aaaa()
             if report[test_instance.name]["verdict"] == test_instance.verdict:
+                # test mailtls null-mx-without-a-aaaa description
+                # test mailtls null-mx-without-a-aaaa summary
                 return "null-mx-without-a-aaaa"
         return verdict
 

--- a/checks/probes.py
+++ b/checks/probes.py
@@ -357,11 +357,12 @@ class Probe:
                 # test mailtls no-null-mx description
                 # test mailtls no-null-mx summary
                 return "no-null-mx"
-            test_instance.result_invalid_null_mx()
+            test_instance.result_null_mx_with_other_mx()
             if report[test_instance.name]["verdict"] == test_instance.verdict:
-                # test mailtls invalid-null-mx description
-                # test mailtls invalid-null-mx summary
-                return "invalid-null-mx"
+                return "null-mx-with-other-mx"
+            test_instance.result_null_mx_without_a_aaaa()
+            if report[test_instance.name]["verdict"] == test_instance.verdict:
+                return "null-mx-without-a-aaaa"
         return verdict
 
     def get_max_score(self, modelobj, maxscore):

--- a/checks/tasks/dnssec.py
+++ b/checks/tasks/dnssec.py
@@ -185,7 +185,7 @@ def save_results_mail(addr, results, category):
         category.subtests["dnssec_mx_exists"].result_no_mailservers()
     elif mailtdnssec.mx_status == MxStatus.no_null_mx:
         category.subtests["dnssec_mx_exists"].result_no_null_mx()
-    elif mailtdnssec.mx_status == MxStatus.invalid_null_mx:
+    elif mailtdnssec.mx_status == MxStatus.null_mx_with_other_mx:
         category.subtests["dnssec_mx_exists"].result_null_mx_with_other_mx()
     elif mailtdnssec.mx_status == MxStatus.null_mx_without_a_aaaa:
         category.subtests["dnssec_mx_exists"].result_null_mx_without_a_aaaa()

--- a/checks/tasks/dnssec.py
+++ b/checks/tasks/dnssec.py
@@ -186,7 +186,9 @@ def save_results_mail(addr, results, category):
     elif mailtdnssec.mx_status == MxStatus.no_null_mx:
         category.subtests["dnssec_mx_exists"].result_no_null_mx()
     elif mailtdnssec.mx_status == MxStatus.invalid_null_mx:
-        category.subtests["dnssec_mx_exists"].result_invalid_null_mx()
+        category.subtests["dnssec_mx_exists"].result_null_mx_with_other_mx()
+    elif mailtdnssec.mx_status == MxStatus.null_mx_without_a_aaaa:
+        category.subtests["dnssec_mx_exists"].result_null_mx_without_a_aaaa()
     elif mailtdnssec.mx_status == MxStatus.null_mx:
         category.subtests["dnssec_mx_exists"].result_null_mx()
 

--- a/checks/tasks/ipv6.py
+++ b/checks/tasks/ipv6.py
@@ -233,8 +233,10 @@ def callback(results, addr, parent, parent_name, category):
                 if len(result.get("domains")) == 0:
                     if parent.mx_status == MxStatus.no_null_mx:
                         category.subtests["mx_aaaa"].result_no_null_mx()
-                    elif parent.mx_status == MxStatus.invalid_null_mx:
-                        category.subtests["mx_aaaa"].result_invalid_null_mx()
+                    elif parent.mx_status == MxStatus.null_mx_with_other_mx:
+                        category.subtests["mx_aaaa"].result_null_mx_with_other_mx()
+                    elif parent.mx_status == MxStatus.null_mx_without_a_aaaa:
+                        category.subtests["mx_aaaa"].result_null_mx_without_a_aaaa()
                     elif parent.mx_status == MxStatus.null_mx:
                         category.subtests["mx_aaaa"].result_null_mx()
                     else:

--- a/checks/tasks/shared.py
+++ b/checks/tasks/shared.py
@@ -113,9 +113,11 @@ def do_mail_get_servers(self, url, *args, **kwargs):
     for prio, rdata in mxlist:
         is_null_mx = prio == 0 and rdata == ""
         if is_null_mx:
-            if len(mxlist) > 1 or not do_resolve_a_aaaa(self, url):
-                # Invalid NULL MX next to other MX or no A/AAAA.
-                return [(None, None, MxStatus.invalid_null_mx)]
+            if len(mxlist) > 1:
+                # Invalid NULL MX next to other MX.
+                return [(None, None, MxStatus.null_mx_with_other_mx)]
+            elif not do_resolve_a_aaaa(self, url):
+                return [(None, None, MxStatus.null_mx_without_a_aaaa)]
             return [(None, None, MxStatus.null_mx)]
 
         rdata = rdata.lower().strip()

--- a/checks/tasks/tls.py
+++ b/checks/tasks/tls.py
@@ -1090,8 +1090,10 @@ def build_summary_report(testtls, category):
             category.subtests["starttls_exists"].result_null_mx()
         elif testtls.mx_status == MxStatus.no_null_mx:
             category.subtests["starttls_exists"].result_no_null_mx()
-        elif testtls.mx_status == MxStatus.invalid_null_mx:
-            category.subtests["starttls_exists"].result_invalid_null_mx()
+        elif testtls.mx_status == MxStatus.null_mx_with_other_mx:
+            category.subtests["starttls_exists"].result_null_mx_with_other_mx()
+        elif testtls.mx_status == MxStatus.null_mx_without_a_aaaa:
+            category.subtests["starttls_exists"].result_null_mx_without_a_aaaa()
         else:
             category.subtests["starttls_exists"].result_no_mailservers()
         server_set = testtls.testset


### PR DESCRIPTION
Needs a split of `detail mail dnssec mx-exists verdict invalid-null-mx` in two labels: https://github.com/internetstandards/Internet.nl_content/pull/29

Can be tested with null-mx-with-other-mx.as213279.net and null-mx-without-a-aaaa.as213279.net

Ref 4417bd3
