### PR TITLE
Fix #943 - Use type=url for input combined with form novalidate

### DIFF
--- a/interface/templates/base-results.html
+++ b/interface/templates/base-results.html
@@ -132,10 +132,10 @@
        <h2>
          {% include "string.html" with name="results test website label" %}
        </h2>
-       <form action="/site/" method="POST">
+       <form action="/site/" method="POST" novalidate>
          <label class="text-input" for="web-url">
            {% include "string.html" with name="base test website input" %}
-           <input id="web-url" type="text" name="url" placeholder="www.example.nl" autocorrect="off" autocapitalize="none" spellcheck="false">
+           <input id="web-url" type="url" name="url" placeholder="www.example.nl" autocorrect="off" autocapitalize="none" spellcheck="false">
          </label>
          <div class="contains-button">
            <button>
@@ -164,11 +164,11 @@
        <h2>
          {% include "string.html" with name="results test email label" %}
        </h2>
-       <form action="/mail/" method="POST">
+       <form action="/mail/" method="POST" novalidate>
          <label class="text-input" for="mail-url">
            {% include "string.html" with name="base test mail input" %}
            <span class="emailfield before">
-             <input id="mail-url" class="email" type="text" name="url" placeholder="example.nl" autocorrect="off" autocapitalize="none" spellcheck="false">
+             <input id="mail-url" class="email" type="url" name="url" placeholder="example.nl" autocorrect="off" autocapitalize="none" spellcheck="false">
            </span>
          </label>
          <div class="contains-button">

--- a/interface/templates/index.html
+++ b/interface/templates/index.html
@@ -22,9 +22,9 @@
                 <a href="/test-site/">{% include "string.html" with name="base test explain" %}</a>
               </p>
             </div>
-            <form action="/site/" method="POST">
+            <form action="/site/" method="POST" novalidate>
               <label class="text-input" for="web-url">{% include "string.html" with name="base test website input" %}
-              <input id="web-url" type="text" name="url" placeholder="www.example.nl" autocorrect="off" autocapitalize="none" spellcheck="false">
+              <input id="web-url" type="url" name="url" placeholder="www.example.nl" autocorrect="off" autocapitalize="none" spellcheck="false">
               </label>
               <div class="contains-button">
                 <button>{% include "string.html" with name="base test start" %}</button>
@@ -41,10 +41,10 @@
                 <a href="/test-mail/">{% include "string.html" with name="base test explain" %}</a>
               </p>
             </div>
-            <form action="/mail/" method="POST">
+            <form action="/mail/" method="POST" novalidate>
               <label class="text-input" for="mail-url">{% include "string.html" with name="base test mail input" %}
                 <span class="emailfield before">
-                <input id="mail-url" class="email" type="text" name="url" placeholder="example.nl" autocorrect="off" autocapitalize="none" spellcheck="false">
+                <input id="mail-url" class="email" type="url" name="url" placeholder="example.nl" autocorrect="off" autocapitalize="none" spellcheck="false">
                 </span>
               </label>
               <div class="contains-button">

--- a/interface/templates/test-mail.html
+++ b/interface/templates/test-mail.html
@@ -5,10 +5,10 @@
       <h1>{% include "string.html" with name="base test mail title" %}</h1>
       {% include "content.html" with name="base test mail explain" %}
     </div>
-    <form action="/mail/" method="POST">
+    <form action="/mail/" method="POST" novalidate>
       <label class="text-input" for="mail-url">{% include "string.html" with name="base test mail input" %}
         <span class="emailfield before">
-          <input id="mail-url" class="email" type="text" name="url" placeholder="example.nl" autocorrect="off" autocapitalize="none" spellcheck="false">
+          <input id="mail-url" class="email" type="url" name="url" placeholder="example.nl" autocorrect="off" autocapitalize="none" spellcheck="false">
         </span>
       </label>
       {% if request.GET.invalid != None %}

--- a/interface/templates/test-site.html
+++ b/interface/templates/test-site.html
@@ -5,9 +5,9 @@
       <h1>{% include "string.html" with name="base test website title" %}</h1>
       {% include "content.html" with name="base test website explain" %}
     </div>
-    <form action="/site/" method="POST">
+    <form action="/site/" method="POST" novalidate>
       <label class="text-input" for="web-url">{% include "string.html" with name="base test website input" %}
-        <input id="web-url" type="text" name="url" placeholder="www.example.nl" autocorrect="off" autocapitalize="none" spellcheck="false">
+        <input id="web-url" type="url" name="url" placeholder="www.example.nl" autocorrect="off" autocapitalize="none" spellcheck="false">
       </label>
       {% if request.GET.invalid != None %}
       <div class="invalid-domain">

--- a/interface/templates/widget-mail.html
+++ b/interface/templates/widget-mail.html
@@ -5,14 +5,14 @@
     {% include "content.html" with name="widget mail intro" %}
     <h2><label for="html-block">HTML</label></h2>
     <div>
-    <textarea id="html-block" readonly>&lt;form action="https://internet.nl/mail/" method="POST"&gt;
+    <textarea id="html-block" readonly>&lt;form action="https://internet.nl/mail/" method="POST" novalidate&gt;
   &lt;p&gt;
     &lt;img class="internetnl" src="https://internet.nl/static/logo_en.svg" alt="{% translate 'page sitedescription' %}"/&gt;
     {% translate 'widget mail html-block' %}
   &lt;/p&gt;
   &lt;label for="internetnl-mail-url"&gt;{% translate 'base test mail input'%}&lt;/label&gt;
   &lt;span class="internetnl emailfield"&gt;
-    &lt;input id="internetnl-mail-url" type="text" name="url" placeholder="example.nl"&gt;
+    &lt;input id="internetnl-mail-url" type="url" name="url" placeholder="example.nl"&gt;
   &lt;/span&gt;
   &lt;button class="internetnl"&gt;{% translate 'base test start'%}&lt;/button&gt;
 &lt;/form&gt;</textarea>

--- a/interface/templates/widget-site.html
+++ b/interface/templates/widget-site.html
@@ -5,13 +5,13 @@
     {% include "content.html" with name="widget site intro" %}
     <h2><label for="html-block">HTML</label></h2>
     <div>
-    <textarea id="html-block" readonly>&lt;form action="https://internet.nl/site/" method="POST"&gt;
+    <textarea id="html-block" readonly>&lt;form action="https://internet.nl/site/" method="POST" novalidate&gt;
   &lt;p&gt;
     &lt;img class="internetnl" src="https://internet.nl/static/logo_en.svg" alt="{% translate 'page sitedescription' %}"/&gt;
     {% translate 'widget site html-block' %}
   &lt;/p&gt;
   &lt;label for="internetnl-site-url"&gt;{% translate 'base test website input'%}&lt;/label&gt;
-  &lt;input id="internetnl-site-url" type="text" name="url" placeholder="www.example.nl"&gt;
+  &lt;input id="internetnl-site-url" type="url" name="url" placeholder="www.example.nl"&gt;
   &lt;button class="internetnl"&gt;{% translate 'base test start'%}&lt;/button&gt;
 &lt;/form&gt;</textarea>
     </div>


### PR DESCRIPTION
Done with
```bash
grep -RE 'form action="(https://internet.nl)?/(site|mail)/" method="POST"|type="text"' interface -l \
| xargs -n1 sed -r -i 's@(form action="(https://internet.nl)?/(site|mail)/" method="POST")@\1 novalidate@g;s/(type=)"text"/\1"url"/g'
```