### PR TITLE
Fixed forced HTTPS redirect check domain match

### DIFF
--- a/checks/tasks/tls.py
+++ b/checks/tasks/tls.py
@@ -2992,7 +2992,8 @@ def forced_http_check(af_ip_pair, url, task):
             parsed_url = urlparse(response.url)
             # Requirement: in case of redirecting, a domain should firstly upgrade itself by
             # redirecting to its HTTPS version before it may redirect to another domain.
-            if parsed_url.scheme == "https" and parsed_url.netloc in url:
+            # However, redirecting to a subdomain, e.g. www-prefix, is permitted.
+            if parsed_url.scheme == "https" and url in parsed_url.netloc:
                 forced_https = ForcedHttpsStatus.good
                 forced_https_score = scoring.WEB_TLS_FORCED_HTTPS_GOOD
 


### PR DESCRIPTION
This fixes a reversed "in" match for HTTPS redirect introduced in c5ba541ac143422a2a2c7f7623cd88c6370f8e63
