### PR TITLE
Fix #1128 - Add timeout and clean up log for http_client

### DIFF
--- a/checks/http_client.py
+++ b/checks/http_client.py
@@ -28,12 +28,20 @@ def _do_request(args, headers, kwargs, session, url):
     following the redirect chain, then ensures response.history is complete.
     """
     user_allow_redirects = kwargs.pop("allow_redirects", True)
-    response = session.get(url, headers=headers, stream=True, allow_redirects=False, *args, **kwargs)
+    response = session.get(
+        url, headers=headers, stream=True, allow_redirects=False, timeout=DEFAULT_TIMEOUT, *args, **kwargs
+    )
     if response.next and user_allow_redirects:
         headers.pop("Host", None)
         initial_response = response
         response = session.get(
-            initial_response.next.url, headers=headers, stream=True, allow_redirects=True, *args, **kwargs
+            initial_response.next.url,
+            headers=headers,
+            stream=True,
+            allow_redirects=True,
+            timeout=DEFAULT_TIMEOUT,
+            *args,
+            **kwargs,
         )
         response.history.insert(0, initial_response)
 
@@ -62,7 +70,7 @@ def http_get(
         try:
             response = _do_request(args, headers, kwargs, session, url)
         except requests.RequestException as exc:
-            log.debug(f"HTTP request raised exception: {url} (headers: {headers}): {exc}", exc_info=exc)
+            log.debug(f"HTTP request raised exception: {url} (headers: {headers}): {exc}")
             raise exc
 
     log.debug(f"HTTP request completed in {timer()-start_time:.06f}s: {url} (headers: {headers})")


### PR DESCRIPTION
For unreachable hosts, the exception handler was triggered,
but at the same time the request did not return. Adding a
timeout to requests calls fixed this.
