### PR TITLE
Ref #1130 - Change HTTPS redirect to NOT_TESTED for unavailable HTTPS

### DIFF
--- a/checks/categories.py
+++ b/checks/categories.py
@@ -913,6 +913,11 @@ class WebTlsHttpsForced(Subtest):
         self.verdict = "detail web tls https-forced verdict other"
         self.tech_data = "detail tech data not-applicable"
 
+    def result_no_https(self):
+        self._status(STATUS_NOT_TESTED)
+        self.verdict = "detail web tls https-forced verdict no-https"
+        self.tech_data = "detail tech data not-applicable"
+
     def result_bad(self):
         self._status(STATUS_FAIL)
         self.verdict = "detail web tls https-forced verdict bad"

--- a/checks/models.py
+++ b/checks/models.py
@@ -73,6 +73,7 @@ class ForcedHttpsStatus(Enum):
     bad = 0
     good = 1
     no_http = 2
+    no_https = 3
 
 
 class OcspStatus(Enum):

--- a/checks/tasks/tls.py
+++ b/checks/tasks/tls.py
@@ -766,6 +766,8 @@ def build_report(dttls, category):
                 category.subtests["https_forced"].result_good()
             elif dttls.forced_https == ForcedHttpsStatus.no_http:
                 category.subtests["https_forced"].result_no_http()
+            elif dttls.forced_https == ForcedHttpsStatus.no_https:
+                category.subtests["https_forced"].result_no_https()
             elif dttls.forced_https == ForcedHttpsStatus.bad:
                 category.subtests["https_forced"].result_bad()
 
@@ -2975,12 +2977,12 @@ def forced_http_check(af_ip_pair, url, task):
     """
     Check if the webserver is properly configured with HTTPS redirection.
     """
-    # First connect on port 80 and see if we get refused
     try:
         http_get_ip(hostname=url, ip=af_ip_pair[1], port=443, https=True)
     except requests.RequestException:
-        # No HTTPS connection available
-        return scoring.WEB_TLS_FORCED_HTTPS_BAD, ForcedHttpsStatus.bad
+        # No HTTPS connection available to our HTTP client.
+        # Could also be too outdated config (#1130)
+        return scoring.WEB_TLS_FORCED_HTTPS_BAD, ForcedHttpsStatus.no_https
 
     try:
         response_http = http_get_ip(hostname=url, ip=af_ip_pair[1], port=80, https=False)

--- a/interface/batch/openapi.yaml
+++ b/interface/batch/openapi.yaml
@@ -765,6 +765,7 @@ components:
             * `good` - HTTPS redirection is enforced.
             * `bad` - HTTPS redirection is not enforced.
             * `no_http` - No HTTP connection; test is not relevant.
+            * `no_https` - No or outdated HTTPS connection; test could not be executed.
         http_compression:
           type: boolean
           description: If HTTP compression is used.


### PR DESCRIPTION
HTTPS redirect test now uses a standard HTTP client that does not support some ancient configurations. This change makes it return as not tested for any HTTPS connection failure. Both the cases where HTTPS is entirely unavailable and just very old, are already caught by other tests.
