### PR TITLE
Provide proper hostname and the container name in Sentry events

### DIFF
--- a/docker/defaults.env
+++ b/docker/defaults.env
@@ -38,6 +38,7 @@ MATOMO_SUBDOMAIN_TRACKING=
 # set DSN and environment for Sentry events
 SENTRY_DSN=
 SENTRY_ENVIRONMENT=unknown
+SENTRY_SERVER_NAME=unknown
 
 # enable batch API
 ENABLE_BATCH=False

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -104,7 +104,8 @@ services:
         condition: service_healthy
       resolver-permissive:
         condition: service_healthy
-
+    # set hostname for Sentry
+    hostname: app
     environment:
       - INTERNET_NL_CHECK_SUPPORT_IPV6
       - INTERNET_NL_CHECK_SUPPORT_DNSSEC
@@ -146,6 +147,7 @@ services:
       - IPV4_IP_RESOLVER_INTERNAL_PERMISSIVE
       - SENTRY_DSN
       - SENTRY_ENVIRONMENT
+      - SENTRY_SERVER_NAME
       - MATOMO_URL
       - MATOMO_SITEID
       - MATOMO_SUBDOMAIN_TRACKING
@@ -251,7 +253,8 @@ services:
         condition: service_healthy
       resolver-permissive:
         condition: service_healthy
-
+    # set hostname for Sentry
+    hostname: worker
     environment:
       - INTERNET_NL_CHECK_SUPPORT_IPV6
       - INTERNET_NL_CHECK_SUPPORT_DNSSEC
@@ -287,6 +290,7 @@ services:
       - IPV4_IP_RESOLVER_INTERNAL_PERMISSIVE
       - SENTRY_DSN
       - SENTRY_ENVIRONMENT
+      - SENTRY_SERVER_NAME
       # even though eventlet is used and childs are not really threads or processes, this settings reduces
       # issues with high memory usage, probably because some objects are freed?
       - CELERYD_MAX_TASKS_PER_CHILD=100
@@ -313,6 +317,8 @@ services:
 
     command: celery --app internetnl worker --without-gossip --pool=eventlet --time-limit=600 --concurrency=$WORKER_CONCURRENCY
       --queues slow_db_worker
+    # set hostname for Sentry
+    hostname: worker-slow
 
   beat:
     image: ${DOCKER_IMAGE_APP:-ghcr.io/internetstandards/internet.nl:${RELEASE:-latest}}
@@ -378,6 +384,7 @@ services:
       - IPV4_IP_RESOLVER_INTERNAL_PERMISSIVE
       - SENTRY_DSN
       - SENTRY_ENVIRONMENT
+      - SENTRY_SERVER_NAME
     healthcheck:
       test: ["CMD", "pgrep", "celery"]
       interval: $HEALTHCHECK_INTERVAL

--- a/docker/host-dist.env
+++ b/docker/host-dist.env
@@ -29,7 +29,10 @@ UNBOUND_PORT_UDP=$IPV4_IP_PUBLIC:53:53/udp
 UNBOUND_PORT_IPV6_TCP=[$IPV6_IP_PUBLIC]:53:53/tcp
 UNBOUND_PORT_IPV6_UDP=[$IPV6_IP_PUBLIC]:53:53/udp
 
+SENTRY_SERVER_NAME=$SENTRY_SERVER_NAME
+
 # modify worker memory limit to allow more concurrent processes
 # WORKER_MEMORY_LIMIT=2G
 # increase concurrent amount of workers
 # WORKER_CONCURRENCY=200
+

--- a/documentation/Docker-deployment.md
+++ b/documentation/Docker-deployment.md
@@ -102,6 +102,7 @@ Use the values determined above to fill in the variables below and run the follo
     INTERNETNL_DOMAINNAME=example.com \
     IPV4_IP_PUBLIC=192.0.2.1 \
     IPV6_IP_PUBLIC=2001:db8:1::1 \
+    SENTRY_SERVER_NAME=$(hostname) \
     envsubst < docker/host-dist.env > docker/host.env
 
 After this a `docker/host.env` file is created. This file is host specific and should not be modified unless something changes in the domainname or IP settings.

--- a/internetnl/settings.py
+++ b/internetnl/settings.py
@@ -13,7 +13,7 @@ For an example, see internet.nl.dist.env.
 
 import os
 from os import getenv
-
+import socket
 import sentry_sdk
 
 from internetnl.settings_utils import (
@@ -637,7 +637,10 @@ if getenv("SENTRY_DSN"):
         before_breadcrumb=remove_sentry_pii,
         # add version number to sentry events
         release=VERSION,
+        # overwrite server_name to not use the container server name
+        server_name=getenv("SENTRY_SERVER_NAME"),
     )
+    sentry_sdk.set_tag("container_name", str(socket.gethostname()))
 
 # Settings for statsd metrics collection. Statsd defaults over UDP port 8125.
 # https://django-statsd.readthedocs.io/en/latest/#celery-signals-integration


### PR DESCRIPTION
add to host.env: SENTRY_SERVER_NAME=internet.nl