### PR TITLE
Remove docker image branch tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -104,11 +104,9 @@ jobs:
           # and tag with PR source branch (eg: feature-x)
           tags: |
             ${{ env.registry }}/${{ matrix.image }}:${{ steps.get_version.outputs.internetnl_version }}
-            ${{ env.registry }}/${{ matrix.image }}:branch-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name}}
           # use latest build from main, or image previously build by this PR for caching
           cache-from: |
             ${{ env.registry }}/${{ matrix.image }}:main
-            ${{ env.registry }}/${{ matrix.image }}:branch-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name}}
           # push images to registry
           push: true
           # makes build images better usable as cache by allowing individual layers to be pulled from cache
@@ -225,15 +223,6 @@ jobs:
               env -i RELEASE="\$RELEASE" docker compose --env-file=docker/defaults.env --env-file=docker/host.env --env-file=docker/local.env pull && \\
               env -i RELEASE="\$RELEASE" docker compose --env-file=docker/defaults.env --env-file=docker/host.env --env-file=docker/local.env up --remove-orphans --wait --no-build
 
-          To deploy the latest build in this PR's branch to a existing deployment run the following update commands:
-
-              export BRANCH="${{ github.head_ref }}" && \\
-              export RELEASE="branch-${{ github.head_ref }}" && \\
-              cd /opt/Internet.nl/ && \\
-              curl -sSfO --output-dir docker https://raw.githubusercontent.com/internetstandards/Internet.nl/\$BRANCH/docker/defaults.env && \\
-              curl -sSfO --output-dir docker https://raw.githubusercontent.com/internetstandards/Internet.nl/\$BRANCH/docker/docker-compose.yml && \\
-              env -i RELEASE="\$RELEASE" docker compose --env-file=docker/defaults.env --env-file=docker/host.env --env-file=docker/local.env pull && \\
-              env -i RELEASE="\$RELEASE" docker compose --env-file=docker/defaults.env --env-file=docker/host.env --env-file=docker/local.env up --remove-orphans --wait --no-build
           EOF
 
       - name: Release deployment docs

--- a/documentation/Docker-deployment.md
+++ b/documentation/Docker-deployment.md
@@ -265,16 +265,6 @@ If you want to update to a tagged version release, e.g. `v1.8.0`, use the follow
     env -i RELEASE=$RELEASE docker compose --env-file=docker/defaults.env --env-file=docker/host.env --env-file=docker/local.env pull && \
     env -i RELEASE=$RELEASE docker compose --env-file=docker/defaults.env --env-file=docker/host.env --env-file=docker/local.env up --remove-orphans --wait --no-build
 
-To update to the latest build of the Pull Request branch use:
-
-    BRANCH=feature-x
-	RELEASE=branch-feature-x && \
-    cd /opt/Internet.nl/ && \
-    curl -sSfO --output-dir docker https://raw.githubusercontent.com/internetstandards/Internet.nl/${BRANCH }/docker/defaults.env && \
-    curl -sSfO --output-dir docker https://raw.githubusercontent.com/internetstandards/Internet.nl/${BRANCH }/docker/docker-compose.yml && \
-    env -i RELEASE=$RELEASE docker compose --env-file=docker/defaults.env --env-file=docker/host.env --env-file=docker/local.env pull && \
-    env -i RELEASE=$RELEASE docker compose --env-file=docker/defaults.env --env-file=docker/host.env --env-file=docker/local.env up --remove-orphans --wait --no-build
-
 The `pull` command might sometimes fail with a timeout error. In that case just retry until it's working. Or check [Github Status](https://www.githubstatus.com) to see if Github is down again.
 
 ## Downgrading/rollback


### PR DESCRIPTION
This was a blocker for builds on branches with slashes. We also don't need it that much, as branch following will be implemented in #1155 by fetching the branch sha and using that for image pulls.