### PR TITLE
Fix #1267 - Allow 4xx and 5xx in IPv4/6 similarity with notice

### DIFF
--- a/checks/categories.py
+++ b/checks/categories.py
@@ -538,6 +538,10 @@ class WebIpv6WsIpv46(Subtest):
         self._status(STATUS_FAIL)
         self.verdict = "detail web ipv6 web-ipv46 verdict bad"
 
+    def result_notice_status_code(self):
+        self._status(STATUS_NOTICE)
+        self.verdict = "detail web ipv6 web-ipv46 verdict notice-status-code"
+
     def result_notice(self):
         self._status(STATUS_NOTICE)
         self.verdict = "detail web ipv6 web-ipv46 verdict notice"


### PR DESCRIPTION
Adds a requirement for a label
`detail web ipv6 web-ipv46 verdict notice-status-code`
