### PR TITLE
Fix #1291 - Compare HTTPS redirect hostname, not netloc (incl port)

### DIFF
--- a/checks/tasks/tls.py
+++ b/checks/tasks/tls.py
@@ -2998,7 +2998,7 @@ def forced_http_check(af_ip_pair, url, task):
             parsed_url = urlparse(response.url)
             # Requirement: in case of redirecting, a domain should firstly upgrade itself by
             # redirecting to its HTTPS version before it may redirect to another domain (#1208)
-            if parsed_url.scheme == "https" and url == parsed_url.netloc:
+            if parsed_url.scheme == "https" and url == parsed_url.hostname:
                 forced_https = ForcedHttpsStatus.good
                 forced_https_score = scoring.WEB_TLS_FORCED_HTTPS_GOOD
             break


### PR DESCRIPTION
When the redirect URL includes an explicit port, as done by some AWS,
the netloc includes this port and comparison would fail.
