### PR TITLE
Limit cache TTL in central unbound in Docker image

### DIFF
--- a/docker/resolver/resolver-permissive.conf.template
+++ b/docker/resolver/resolver-permissive.conf.template
@@ -12,6 +12,9 @@ server:
   module-config: "iterator"
   chroot: ""
 
+  cache-max-ttl: 60
+  cache-max-negative-ttl: 60
+
   logfile: /dev/stdout
   ${DEBUG_LOG_UNBOUND_STATEMENTS}
 

--- a/docker/resolver/resolver-validating.conf.template
+++ b/docker/resolver/resolver-validating.conf.template
@@ -12,6 +12,9 @@ server:
   module-config: "validator iterator"
   chroot: ""
 
+  cache-max-ttl: 60
+  cache-max-negative-ttl: 60
+  
   logfile: /dev/stdout
   ${DEBUG_LOG_UNBOUND_STATEMENTS}
 


### PR DESCRIPTION
See comments in #1292. Prevents stale responses.
