### PR TITLE
Update sectxt dependency to 0.8.3+hotfix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.8.5
+
+Release 1.8.5 contains a hotfix for the [sectxt library failing on leap days](https://github.com/DigitalTrustCenter/sectxt/issues/66).
+
 ## 1.8.4
 
 Release 1.8.4:
@@ -8,7 +12,7 @@ Release 1.8.4:
 - Restricts HTTPS redirects to the same domain, no longer allowing directions to a subdomain first (#1208).
 - Updates a number of other dependencies.
 - Fixes an issue where certbot renewals were not correctly run.
-- 
+
 ## 1.8.3
 
 Release 1.8.3 fixes an issue where HSTS and CSP headers were missing from he www-subdomain of the main domain (#1210, #1211).

--- a/requirements.txt
+++ b/requirements.txt
@@ -163,7 +163,7 @@ requests==2.31.0
     #   sectxt
 rjsmin==1.2.1
     # via -r requirements.in
-sectxt==0.8.3
+sectxt @ https://github.com/mxsasha/sectxt/archive/refs/tags/0.8.3_leap.tar.gz
     # via -r requirements.in
 selenium==3.141.0
     # via -r requirements.in


### PR DESCRIPTION
For https://github.com/DigitalTrustCenter/sectxt/issues/66