### PR TITLE
Add info for additional languages to customizing documentation

### DIFF
--- a/documentation/Customize.md
+++ b/documentation/Customize.md
@@ -17,8 +17,31 @@ adding the above files.
 
 You need to translate all the strings in `main.po`.
 
+To add a new meny entry for the new language, you also need to update the file
+
+`internet.nl/settings.py`
+
+and to have the webserver correctly route the traffic to the newly created
+language and correctly create the LE certificates the
+
+`webserver/nginx_templates/app.conf.template`
+
+needs to be updated according in various places. This also presumes you
+have the corresponding DNS entries already created, such as
+
+```
+[lang].example.nl
+[lang].fr.ipv6.example.nl
+[lang].conn.example.nl
+[lang].conn.ipv6.example.nl
+```
+
+where [lang] is the 2 letter ISO 639-1 language code.
+
+Then, update the site using the procedure in [documentation/Docker-forked.md](Docker-forked.md) to rebuild the front accordingly.
+
 For `news.po` you can provide your own news/blogs but you need to follow the
-existing conventions.
+existing conventions. (**FIXME**: this needs further clarification)
 
 
 ## Scores

--- a/documentation/Customize.md
+++ b/documentation/Customize.md
@@ -17,16 +17,12 @@ adding the above files.
 
 You need to translate all the strings in `main.po`.
 
-To add a new meny entry for the new language, you also need to update the file
+To add a new meny entry for the new language:
+* add the language to `internet.nl/settings.py`
+* update `webserver/nginx_templates/app.conf.template` to include the language
+* update `docker/webserver/certbot.sh` to request LE certs for the new subdomain
 
-`internet.nl/settings.py`
-
-and to have the webserver correctly route the traffic to the newly created
-language and correctly create the LE certificates the
-
-`webserver/nginx_templates/app.conf.template`
-
-needs to be updated according in various places. This also presumes you
+This presumes you
 have the corresponding DNS entries already created, such as
 
 ```


### PR DESCRIPTION
Clarifications on adding a new language.

When creating the french translation for a fork of the site here: https://conformite-internet.fr/ I had a few challenges getting this to work, hence the proposed small update to this document. Thanks to @mxsasha and @aequitas for pointing me in the right direction. As I go along to build the site and try to customise it, I shall note any other documentation updates if/where necessary in the hope this is useful.

Kind regards,

Joris.