### PR TITLE
[WIP] Fix on batch exit (stops the auth ns)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -550,6 +550,7 @@ services:
       - $UNBOUND_PORT_IPV6_UDP
 
     environment:
+      - ENABLE_BATCH
       - DEBUG_LOG_UNBOUND
       - IPV4_IP_PUBLIC
       - IPV6_IP_PUBLIC

--- a/docker/unbound/entrypoint.sh
+++ b/docker/unbound/entrypoint.sh
@@ -4,6 +4,10 @@ set -e
 
 cd /opt/unbound/etc/unbound/
 
+if [ "$ENABLE_BATCH" = "True" ]; then
+  exit 0;
+fi
+
 if [ "$DEBUG_LOG_UNBOUND" = "True" ];then
   export DEBUG_LOG_UNBOUND_STATEMENTS="verbosity: 2
   log-queries: yes"


### PR DESCRIPTION
Fist try in fixing #1330

However:
- the app requires a healthy unbound:
https://github.com/internetstandards/Internet.nl/blob/49d58ddd9ba243b5dce7640aa6ca0cb1296a398c/docker/docker-compose.yml#L105-L106
- the workers require a healthy unbound:
https://github.com/internetstandards/Internet.nl/blob/49d58ddd9ba243b5dce7640aa6ca0cb1296a398c/docker/docker-compose.yml#L253-L254
- the health check of unbound will fail if the unbound is stopped (also with `exit 0`):
https://github.com/internetstandards/Internet.nl/blob/49d58ddd9ba243b5dce7640aa6ca0cb1296a398c/docker/docker-compose.yml#L562-L568