### PR TITLE
Add notes on INTERNETNL_CACHE_TTL on batch

### DIFF
--- a/docker/host-dist.env
+++ b/docker/host-dist.env
@@ -36,3 +36,7 @@ SENTRY_SERVER_NAME=$SENTRY_SERVER_NAME
 # increase concurrent amount of workers
 # WORKER_CONCURRENCY=200
 
+# "cache" ttl - also used for many other things, like wait times in single test.
+# Useful to increase ONLY IN BATCH.
+# Changing in single test will cause unexpected behaviour.
+# INTERNETNL_CACHE_TTL=200

--- a/documentation/Docker-deployment-batch.md
+++ b/documentation/Docker-deployment-batch.md
@@ -92,7 +92,7 @@ The `IPV4_IP_PUBLIC` and `IPV6_IP_PUBLIC` must be configured to localhost addres
     IPV6_IP_PUBLIC=::1 \
     envsubst < docker/host-dist.env > docker/host.env
 
-After this a `docker/host.env` file is created. This file is host specific and should not have to be modified unless something changes in the domainname settings.
+After this a `docker/host.env` file is created. This file is host specific and should not have to be modified unless something changes in the domainname settings. For batch, you may want to set `INTERNETNL_CACHE_TTL` to e.g. an hour, particularly to avoid frequent tests on common mailserver.
 
 For instance specific configuration use the `docker/local.env` file. Please refer to the `docker/defaults.env` file which contains all configurable settings. Please **do not** modify the `docker/defaults.env` file itself as it will be overwritten in updates.
 


### PR DESCRIPTION
Review of the use of CACHE_TTL suggests it is safe to change this.
On single test, there are many side effects, and it should stay as is.
