### PR TITLE
Allow NULL on BatchUser fields to make checks/0015_auto migration reversible

### DIFF
--- a/checks/migrations/0001_initial.py
+++ b/checks/migrations/0001_initial.py
@@ -80,9 +80,9 @@ class Migration(migrations.Migration):
             fields=[
                 ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
                 ("username", models.CharField(max_length=255, unique=True)),
-                ("name", models.CharField(max_length=255)),
-                ("organization", models.CharField(max_length=255)),
-                ("email", models.EmailField(max_length=255)),
+                ("name", models.CharField(max_length=255, null=True)),
+                ("organization", models.CharField(max_length=255, null=True)),
+                ("email", models.EmailField(max_length=255, null=True)),
             ],
         ),
         migrations.CreateModel(


### PR DESCRIPTION
This is a bit sneaky because it alters an older migration, but as
these fields are never actually used, the impact is none.
Making checks/0015_auto reversible is required to allow downgrades
from 1.9 to 1.8.
