### PR TITLE
Newer docker version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -402,6 +402,7 @@ jobs:
     env:
       # used in `docker-compose.yml` files to determine version of images to pull
       RELEASE: "${{ needs.build-docker.outputs.internetnl_version }}"
+      PY_COLORS: "1"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,6 +50,11 @@ jobs:
       internetnl_version: ${{ steps.get_version.outputs.internetnl_version }}
 
     steps:
+      - name: Debug info
+        run: |
+          docker version --format '{{.Server.Version}}'
+          docker compose version --short
+
       - uses: actions/checkout@v4
         # include vendor/ submodules used to build dependencies like nassl and unbound
         with:
@@ -277,6 +282,11 @@ jobs:
           # upgrade Docker
           sudo apt install --upgrade docker-ce docker-compose-plugin
 
+      - name: Debug info
+        run: |
+          docker version --format '{{.Server.Version}}'
+          docker compose version --short
+
       - name: Enable ip6tables in Docker
         run: |
           sudo bash -c 'echo "{ \"ip6tables\": true, \"experimental\":true}" > /etc/docker/daemon.json'
@@ -367,6 +377,11 @@ jobs:
       RELEASE: "${{ needs.build-docker.outputs.internetnl_version }}"
 
     steps:
+      - name: Debug info
+        run: |
+          docker version --format '{{.Server.Version}}'
+          docker compose version --short
+
       - uses: actions/checkout@v4
 
       # login to pull images from Github registry
@@ -405,6 +420,11 @@ jobs:
       PY_COLORS: "1"
 
     steps:
+      - name: Debug info
+        run: |
+          docker version --format '{{.Server.Version}}'
+          docker compose version --short
+
       - uses: actions/checkout@v4
 
       # login to pull images from Github registry
@@ -457,6 +477,11 @@ jobs:
       RELEASE: "${{ needs.build-docker.outputs.internetnl_version }}"
 
     steps:
+      - name: Debug info
+        run: |
+          docker version --format '{{.Server.Version}}'
+          docker compose version --short
+
       - uses: actions/checkout@v4
 
       # login to pull images from Github registry
@@ -563,6 +588,11 @@ jobs:
 
           # upgrade Docker
           sudo apt install --upgrade docker-ce docker-compose-plugin
+
+      - name: Debug info
+        run: |
+          docker version --format '{{.Server.Version}}'
+          docker compose version --short
 
       - name: Enable ip6tables in Docker
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -259,6 +259,24 @@ jobs:
       PY_COLORS: "1"
 
     steps:
+      - if: matrix.os  == 'ubuntu-24.04'
+        name: Upgrade to at least Docker 26.1.3 to fix DNS issues
+        run: |
+          # install Docker apt repository
+          sudo apt update
+          sudo apt-get install ca-certificates curl
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+
+          # upgrade Docker
+          sudo apt install --upgrade docker-ce
+
       - name: Enable ip6tables in Docker
         run: |
           sudo bash -c 'echo "{ \"ip6tables\": true, \"experimental\":true}" > /etc/docker/daemon.json'
@@ -527,6 +545,24 @@ jobs:
       PY_COLORS: "1"
 
     steps:
+      - if: matrix.os  == 'ubuntu-24.04'
+        name: Upgrade to at least Docker 26.1.3 to fix DNS issues
+        run: |
+          # install Docker apt repository
+          sudo apt update
+          sudo apt-get install ca-certificates curl
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+
+          # upgrade Docker
+          sudo apt install --upgrade docker-ce
+
       - name: Enable ip6tables in Docker
         run: |
           sudo bash -c 'echo "{ \"ip6tables\": true, \"experimental\":true}" > /etc/docker/daemon.json'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -244,7 +244,14 @@ jobs:
 
   integration-test:
     needs: [build-docker]
-    runs-on: ubuntu-22.04
+
+    # Due to some changes in the handling of config files in Compose, some configurations might not work
+    # on older or newer versions of Docker/Compose. Use a matrix to test both.
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, ubuntu-22.04]
 
     env:
       # used in `docker-compose.yml` files to determine version of images to pull
@@ -320,7 +327,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: Playwright integration test results (screenshots, video)
+          name: Playwright integration test results (screenshots, video) ${{ matrix.os }}
           path: test-results/
           if-no-files-found: ignore
 
@@ -328,7 +335,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: Integration test Docker Compose Logs
+          name: Integration test Docker Compose Logs ${{matrix.os}}
           path: docker-compose.log
           if-no-files-found: ignore
 
@@ -505,7 +512,14 @@ jobs:
 
   batch-integration-test:
     needs: [build-docker]
-    runs-on: ubuntu-22.04
+
+    # Due to some changes in the handling of config files in Compose, some configurations might not work
+    # on older or newer versions of Docker/Compose. Use a matrix to test both.
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, ubuntu-22.04]
 
     env:
       # used in `docker-compose.yml` files to determine version of images to pull
@@ -578,7 +592,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: Playwright batch test results (screenshots, video)
+          name: Playwright batch test results (screenshots, video) ${{ matrix.os }}
           path: test-results/
           if-no-files-found: ignore
 
@@ -586,6 +600,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: Batch test Docker Compose Logs
+          name: Batch test Docker Compose Logs ${{ matrix.os }}
           path: docker-compose.log
           if-no-files-found: ignore

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -275,7 +275,7 @@ jobs:
           sudo apt-get update
 
           # upgrade Docker
-          sudo apt install --upgrade docker-ce
+          sudo apt install --upgrade docker-ce docker-compose-plugin
 
       - name: Enable ip6tables in Docker
         run: |
@@ -562,7 +562,7 @@ jobs:
           sudo apt-get update
 
           # upgrade Docker
-          sudo apt install --upgrade docker-ce
+          sudo apt install --upgrade docker-ce docker-compose-plugin
 
       - name: Enable ip6tables in Docker
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -250,13 +250,7 @@ jobs:
   integration-test:
     needs: [build-docker]
 
-    # Due to some changes in the handling of config files in Compose, some configurations might not work
-    # on older or newer versions of Docker/Compose. Use a matrix to test both.
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-22.04]
+    runs-on: ubuntu-24.04
 
     env:
       # used in `docker-compose.yml` files to determine version of images to pull
@@ -264,8 +258,7 @@ jobs:
       PY_COLORS: "1"
 
     steps:
-      - if: matrix.os  == 'ubuntu-24.04'
-        name: Upgrade to at least Docker 26.1.3 to fix DNS issues
+      - name: Install specific Docker/Compose versions that are known to work
         run: |
           # install Docker apt repository
           sudo apt update
@@ -280,7 +273,7 @@ jobs:
           sudo apt-get update
 
           # upgrade Docker
-          sudo apt install --upgrade docker-ce docker-compose-plugin
+          sudo apt install --upgrade docker-ce docker-compose-plugin=2.27.0\*
 
       - name: Debug info
         run: |
@@ -412,7 +405,7 @@ jobs:
 
   test:
     needs: [build-docker]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     env:
       # used in `docker-compose.yml` files to determine version of images to pull
@@ -420,6 +413,23 @@ jobs:
       PY_COLORS: "1"
 
     steps:
+      - name: Install specific Docker/Compose versions that are known to work
+        run: |
+          # install Docker apt repository
+          sudo apt update
+          sudo apt-get install ca-certificates curl
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+
+          # upgrade Docker
+          sudo apt install --upgrade docker-ce docker-compose-plugin=2.27.0\*
+
       - name: Debug info
         run: |
           docker version --format '{{.Server.Version}}'
@@ -470,13 +480,30 @@ jobs:
 
   development-environment-test:
     needs: [build-docker]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     env:
       # used in `docker-compose.yml` files to determine version of images to pull
       RELEASE: "${{ needs.build-docker.outputs.internetnl_version }}"
 
     steps:
+      - name: Install specific Docker/Compose versions that are known to work
+        run: |
+          # install Docker apt repository
+          sudo apt update
+          sudo apt-get install ca-certificates curl
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+
+          # upgrade Docker
+          sudo apt install --upgrade docker-ce docker-compose-plugin=2.27.0\*
+
       - name: Debug info
         run: |
           docker version --format '{{.Server.Version}}'
@@ -557,13 +584,7 @@ jobs:
   batch-integration-test:
     needs: [build-docker]
 
-    # Due to some changes in the handling of config files in Compose, some configurations might not work
-    # on older or newer versions of Docker/Compose. Use a matrix to test both.
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-22.04]
+    runs-on: ubuntu-24.04
 
     env:
       # used in `docker-compose.yml` files to determine version of images to pull
@@ -571,8 +592,7 @@ jobs:
       PY_COLORS: "1"
 
     steps:
-      - if: matrix.os  == 'ubuntu-24.04'
-        name: Upgrade to at least Docker 26.1.3 to fix DNS issues
+      - name: Install specific Docker/Compose versions that are known to work
         run: |
           # install Docker apt repository
           sudo apt update
@@ -587,7 +607,7 @@ jobs:
           sudo apt-get update
 
           # upgrade Docker
-          sudo apt install --upgrade docker-ce docker-compose-plugin
+          sudo apt install --upgrade docker-ce docker-compose-plugin=2.27.0\*
 
       - name: Debug info
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ production.env
 
 test-results.xml
 docker/local.env
+
+# config dumps from make docker-compose-config-to-file
+config-compose-*

--- a/Makefile
+++ b/Makefile
@@ -470,6 +470,14 @@ run-shell: cmd=/bin/bash
 run-shell:
 	${DOCKER_COMPOSE_UP_PULL_CMD} run ${run_args} --entrypoint ${cmd} ${service}
 
+# show result of merging .yml docker compose config files
+docker-compose-config:
+	${DOCKER_COMPOSE_UP_PULL_CMD} config
+
+# dump the merged compose config to a file with the versions of docker and compose for easier comparison
+docker-compose-config-to-file:
+	${DOCKER_COMPOSE_UP_PULL_CMD} config > "config-compose-$$(docker compose version --short)-$$(docker version -f 'server-{{.Server.Version}}-client-{{.Client.Version}}').yml"
+
 docker-compose-create-superuser:
 	${DOCKER_COMPOSE_CMD} exec app ./manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_superuser('admin', 'admin@example.com', 'admin')"
 

--- a/Makefile
+++ b/Makefile
@@ -521,7 +521,7 @@ batch-api-create-db-indexes docker-compose-batch-api-create-db-indexes:
 tests ?= .
 integration-tests: env=test
 integration-tests:
-	${DOCKER_COMPOSE_UP_PULL_CMD} run --rm test-runner --screenshot=only-on-failure --video=retain-on-failure --junit-xml=test-results.xml ${_test_args} ${test_args} -k'${tests}' integration_tests/common/ integration_tests/integration/
+	${DOCKER_COMPOSE_UP_PULL_CMD} run --rm test-runner --browser=firefox --screenshot=only-on-failure --video=retain-on-failure --junit-xml=test-results.xml ${_test_args} ${test_args} -k'${tests}' integration_tests/common/ integration_tests/integration/
 	@echo -e "\nTo run with only specific tests use the 'tests' argument with part of the test's name, for example: make integration-tests tests=test_index_http_ok\n"
 
 integration-tests-verbose: _test_args=--verbose --verbose
@@ -535,7 +535,7 @@ integration-tests-trace: integration-tests
 
 batch-tests: env=batch-test
 batch-tests:
-	${DOCKER_COMPOSE_UP_PULL_CMD} run --rm test-runner --screenshot=only-on-failure --video=retain-on-failure --junit-xml=test-results.xml ${_test_args} ${test_args} -k'${tests}' integration_tests/common/ integration_tests/batch/
+	${DOCKER_COMPOSE_UP_PULL_CMD} run --rm test-runner --browser=firefox --screenshot=only-on-failure --video=retain-on-failure --junit-xml=test-results.xml ${_test_args} ${test_args} -k'${tests}' integration_tests/common/ integration_tests/batch/
 
 batch-tests-verbose: _test_args=--verbose --verbose
 batch-tests-verbose: batch-tests

--- a/docker/docker-compose-integration-tests.yml
+++ b/docker/docker-compose-integration-tests.yml
@@ -45,8 +45,11 @@ services:
     profiles:
       - build
       - run-tests
-    # configure internal Unbound service for resolving as Docker internal DNS server can be unreliable
-    dns: $IPV4_IP_MOCK_RESOLVER_PUBLIC
+    # configure internal mock resolver for isolated network
+    dns:
+      - $IPV4_IP_MOCK_RESOLVER_PUBLIC
+      - $IPV6_IP_MOCK_RESOLVER_PUBLIC
+
     # also disable search domains and force default resolv settings
     dns_search: [.]
     dns_opt: ["ndots:0", "timeout:5", "attempts:2"]

--- a/docker/docker-compose-integration-tests.yml
+++ b/docker/docker-compose-integration-tests.yml
@@ -42,6 +42,7 @@ services:
     environment:
       - COMPOSE_PROJECT_NAME
       - ENABLE_BATCH
+      - PY_COLORS
     profiles:
       - build
       - run-tests

--- a/docker/docker-compose-integration-tests.yml
+++ b/docker/docker-compose-integration-tests.yml
@@ -189,9 +189,10 @@ networks:
     internal: false
     driver: bridge
 
-  public-internet:
+  public-internet: !override
     # make public network internal as well to run tests isolated from the internet
     internal: true
+
     # required to enable IPv6 on Docker Desktop runtime
     enable_ipv6: true
     driver: bridge

--- a/docker/docker-compose-test.yml
+++ b/docker/docker-compose-test.yml
@@ -36,6 +36,7 @@ services:
       - DEBUG_LOG
       - IPV4_IP_RESOLVER_INTERNAL_VALIDATING
       - IPV4_IP_RESOLVER_INTERNAL_PERMISSIVE
+      - PY_COLORS
       # TODO: to properly isolate tests this line needs to be uncommented, see above
       # - INTEGRATION_TESTS
 

--- a/documentation/Docker-development-environment.md
+++ b/documentation/Docker-development-environment.md
@@ -203,6 +203,16 @@ If the above is not enough: "have you tried turning it on and off again?". Reboo
 
 Otherwise on Mac, try factory resetting Docker: https://docs.docker.com/desktop/troubleshoot/overview/
 
+### Docker compose configuration files
+
+Different versions of Docker Compose may have different ways of processing configuration files or the way they are merged. If you suspect there is an issue due to a newer version of Docker Compose, to see what the final configuration file looks like after merging for example `docker-compose.yml` and `docker-compose-intergration-test.yml` for the `test` environment run:
+
+    make docker-compose-config env=test
+
+For convenience you can store the config files in versioned files so they can be diffed, using the commands:
+
+    make docker-compose-config-to-file env=test
+
 ## IPv6 support
 
 IPv6 support in the development environment is not enabled by default and must be especially configured depending on your setup. On Linux hosts it will mostly work if you have native IPv6. On Mac all Docker runtimes are implemented using Linux VM's which means some additional setup is needed which is not supported on all runtimes.

--- a/documentation/Docker-development-environment.md
+++ b/documentation/Docker-development-environment.md
@@ -213,6 +213,16 @@ For convenience you can store the config files in versioned files so they can be
 
     make docker-compose-config-to-file env=test
 
+### Known error messages
+
+#### Incompatible Docker/Compose version
+
+The following error messages indicate a Docker or Compose version which is not supported. Please refer to `documentation/Docker-getting-started.md#Prerequisites` for compatible versions.
+
+Incompatible Compose version:
+
+    no configuration file provided: not found
+
 ## IPv6 support
 
 IPv6 support in the development environment is not enabled by default and must be especially configured depending on your setup. On Linux hosts it will mostly work if you have native IPv6. On Mac all Docker runtimes are implemented using Linux VM's which means some additional setup is needed which is not supported on all runtimes.

--- a/documentation/Docker-getting-started.md
+++ b/documentation/Docker-getting-started.md
@@ -9,9 +9,14 @@ An OCI compatible container runtime with [Compose V2](https://docs.docker.com/co
 - [Docker](https://docs.docker.com/get-docker/) for Linux, (supported, tested version 24.0.2)
 - [Docker](https://docs.docker.com/get-docker/) for Mac (supported, tested version 4.21.0)
 - [Colima](https://github.com/abiosoft/colima) for Mac (recommended, tested version 0.5.5)
+- [OrbStack](https://orbstack.dev/download) for Mac (non open source, free, tested version 1.6.1)
 - [Docker](https://docs.docker.com/get-docker/) for Windows (untested)
 
-**notice**: newer versions of Docker (25+) might experience issues with internal DNS resolver. This is possibly a bug in Docker Compose:
+**notice**: some versions of Docker Engine might experience issues with internal DNS resolving and will cause tests to fail. Versions from and including `25.0.5` to and including `26.1.2` should be avoided.
+
+At time of writing the latest Colima version (`v0.6.9`) does not yet contain the correct Docker Engine version. To update the Docker Engine to the latest version manually for the time being run the following command:
+
+    colima ssh -- sudo /bin/sh -c 'apt update; apt install --upgrade docker-ce'
 
 **notice**: your Docker runtime should be configured with enough memory and CPU, otherwise the environment will be unstable. Minimum is at least 4GB memory and 2 CPU cores, more is better for quicker rebuild/restart of images/containers.
 

--- a/documentation/Docker-getting-started.md
+++ b/documentation/Docker-getting-started.md
@@ -11,7 +11,7 @@ An OCI compatible container runtime with [Compose V2](https://docs.docker.com/co
 - [Colima](https://github.com/abiosoft/colima) for Mac (recommended, tested version 0.5.5)
 - [Docker](https://docs.docker.com/get-docker/) for Windows (untested)
 
-**notice**: newer versions of Docker (25+) and Docker Compose (v2.24+) might experience issues with internal DNS resolver or when creating the networks required for development/testing. This is possibly a bug in Docker Compose:
+**notice**: newer versions of Docker (25+) might experience issues with internal DNS resolver. This is possibly a bug in Docker Compose:
 
 **notice**: your Docker runtime should be configured with enough memory and CPU, otherwise the environment will be unstable. Minimum is at least 4GB memory and 2 CPU cores, more is better for quicker rebuild/restart of images/containers.
 

--- a/documentation/Docker-getting-started.md
+++ b/documentation/Docker-getting-started.md
@@ -18,6 +18,8 @@ At time of writing the latest Colima version (`v0.6.9`) does not yet contain the
 
     colima ssh -- sudo /bin/sh -c 'apt update; apt install --upgrade docker-ce'
 
+**notice**: Docker Compose Plugin versions from `2.24` up to `2.27.0` should be avoided. `2.27.0` is supported but `2.27.1` is not. At the time a newer version which is supported is to be released.
+
 **notice**: your Docker runtime should be configured with enough memory and CPU, otherwise the environment will be unstable. Minimum is at least 4GB memory and 2 CPU cores, more is better for quicker rebuild/restart of images/containers.
 
 **for arm users (eg apple m1)**: nassl will not compile on x64 architectures, so use the option to start your container engine in x86 mode. For colima this can be done with `colima start --arch x86_64`. As per the system requirements noted above, the right way to start with colima would then be: `colima start --arch x86_64 --cpu 2 --memory 4`, but giving it some room would make that: `colima start --arch x86_64 --cpu 4 --memory 8`.

--- a/integration_tests/common/conftest.py
+++ b/integration_tests/common/conftest.py
@@ -1,0 +1,20 @@
+import subprocess
+import pytest
+from packaging.version import Version
+
+
+def pytest_sessionstart():
+    """Some versions of Docker/Compose are incompatible because of the way their networking/DNS
+    works. Check this and instruct the user how to resolve the issues."""
+
+    docker_server_version = subprocess.check_output(
+        "docker version --format '{{.Server.Version}}'",
+        shell=True,
+        universal_newlines=True,
+    ).strip()
+
+    if Version("25.0.5") <= Version(docker_server_version) < Version("26.1.3"):
+        pytest.fail(
+            f"Docker Server version {docker_server_version} not compatible, refer to "
+            "`documentation/Docker-getting-started.md#Prerequisites` for more info."
+        )

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -199,7 +199,7 @@ def pytest_report_header(config):
 
     try:
         docker_compose_version = subprocess.check_output(
-            "    docker compose version --short", shell=True, universal_newlines=True
+            "docker compose version --short", shell=True, universal_newlines=True
         ).strip()
     except Exception:
         docker_compose_version = "n/a"


### PR DESCRIPTION
This PR fixes several issues with newer Docker/Compose versions:

- Compose version 2.24 and later have changed the way network configurations are merged when using multiple compose files (like in integration tests). Instead of overriding the network config it is now merged. By specifying `!override` in the YAML file explicitly we get the expected behaviour on newer version which is backwards compatible with older versions as well. 
- Docker versions between 25.0.5 and 26.1.2 have issues with internal DNS resolving using the mock resolver. There is no practical workaround for this so these versions should be avoided, this is documented and will be checked by the test runner before starting tests.
- Chromium does not support IPv6 resolving (at all, not even local!) if it fails an global IPv6 connectivity check (which requires internet, in an isolated environment), causing a few tests (`ipv6.internet.nl` domains and the connection test) to fail. Switching to Firefox as browser used for testing. There might be a way to override this behaviour in Chrome using the `IPv6ReachabilityOverrideEnabled` policy, but so far I have not been able to make it work inside the playwright Docker image using available documentation. Firefox does seem a little bit slower on executing the tests so we might want to switch back to Chrome if we can.
- Docker Compose 2.24 broke the way .env files were handled (error: `no configuration file provided: not found`). This has been fixed in 2.27.0 but seems to be broken again in 2.27.1 due to https://github.com/docker/compose/issues/11880. Currently Compose in CI  will be pinned to 2.27.0.

Besides the fixes the following changes are included:

- Compatible versions have been documented.
- Compatible Docker versions are checked before running tests to warn the user and direct them to the proper documentation.
- tests are added to verify if the integration test environment is properly isolated.
- the mock resolver used in integration testing is now accessible over IPv6.
- both old and new versions of Docker/Compose are tested by using a matrix to ensure both versions keep working.
- colors are enabled in pytest output in CI.