### PR TITLE
Translations and content for forked deployments

### DIFF
--- a/bin/pofiles.py
+++ b/bin/pofiles.py
@@ -24,6 +24,7 @@ KNOWN_PO_FILES = [
     ("main.po", []),
     ("news.po", ['article', 'author']),
     ("manual_hof.po", ['manual halloffame']),
+    ("custom.po", []),
 ]
 PO_FILES_DIR = "translations"
 PO_FILES_LOCALES = PO_FILES_DIR + "/{}"

--- a/bin/pofiles.py
+++ b/bin/pofiles.py
@@ -154,8 +154,7 @@ def build_django_files(args=None):
             try:
                 merged_po = merge(merged_po, po_file)
             except ValueError as e:
-                print(f"{e} in {locale}/{filename}. Aborting...")
-                return
+                raise Exception(f"{e} in {locale}/{filename}. Aborting...")
         merged_po.sort()
         print(f"Converting '{locale}' locale to markdown...")
         for entry in merged_po:

--- a/docker/defaults.env
+++ b/docker/defaults.env
@@ -205,7 +205,15 @@ CRON_WEEKLY_POSTGRESQL_BACKUP=False
 # enable running tests every 15 minutes for metrics collection
 CRON_15MIN_RUN_TESTS=True
 
+# enables internet.nl specific content (eg: contact information, faq, security.txt), only enable for internet.nl
+# instances. For customization see: documentation/Customize.md
 INTERNETNL_BRANDING=False
+
+# defines which languages are supported. DNS entries should be created for all languages in the list. The first
+# language in the list is the default if no user preference is set. For valid language codes see this list:
+# http://www.i18nguy.com/unicode/language-identifiers.html
+# also see: documentation/Customize.md
+LANGUAGES=en,nl
 
 # enable caching, set to off to disable
 NGINX_PROXY_CACHE=default_cache

--- a/docker/docker-compose-integration-tests.yml
+++ b/docker/docker-compose-integration-tests.yml
@@ -43,6 +43,7 @@ services:
       - COMPOSE_PROJECT_NAME
       - ENABLE_BATCH
       - PY_COLORS
+      - INTERNETNL_BRANDING
     profiles:
       - build
       - run-tests

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - REDIRECT_DOMAINS
       - NGINX_PROXY_CACHE
       - INTERNETNL_BRANDING
+      - LANGUAGES
 
     # webserver does not depend on any of the other services directly. So it can
     # be started and kept running independently from the other services to
@@ -156,6 +157,8 @@ services:
       - INTERNETNL_BRANDING
       - INTERNETNL_DOMAINNAME
       - USER_AGENT_URL
+      - LANGUAGES
+
     healthcheck:
       test: ["CMD", "nc", "-z", "127.0.0.1", "8080"]
       interval: $HEALTHCHECK_INTERVAL
@@ -985,4 +988,3 @@ networks:
       - subnet: $IPV6_SUBNET_PUBLIC
         gateway: $IPV6_GATEWAY_PUBLIC
       - subnet: $IPV4_SUBNET_PUBLIC
-

--- a/docker/webserver.Dockerfile
+++ b/docker/webserver.Dockerfile
@@ -29,7 +29,10 @@ COPY docker/webserver/user_manage_inner.sh /user_manage_inner.sh
 RUN mkdir -p /var/www/internet.nl/
 
 COPY robots.txt /var/www/internet.nl/
-COPY .well-known/ /var/www/internet.nl/.well-known/
+
+RUN mkdir -p /var/www/internet.nl/.well-known/
+# copy all security*.txt files
+COPY .well-known/security*.txt /var/www/internet.nl/.well-known/
 COPY interface/static/favicon.ico /var/www/internet.nl/
 
 COPY docker/webserver/nginx_templates/* /etc/nginx/templates/

--- a/docker/webserver/10-variables.envsh
+++ b/docker/webserver/10-variables.envsh
@@ -1,3 +1,5 @@
 #!/bin/bash
 # split comma separated list into space separated
 export REDIRECT_DOMAINS_LIST=$(echo $REDIRECT_DOMAINS | sed 's/,/ /')
+
+export LANGUAGES_REGEX=$(echo $LANGUAGES | tr ',' '|')

--- a/docker/webserver/certbot.sh
+++ b/docker/webserver/certbot.sh
@@ -28,9 +28,19 @@ if [ ! -z $CERTBOT_EAB_HMAC_KEY ]; then
 fi
 
 domain=$INTERNETNL_DOMAINNAME
-subdomains="nl.$domain,en.$domain,www.$domain,ipv6.$domain,nl.ipv6.$domain,en.ipv6.$domain"
+subdomains="www.$domain,ipv6.$domain"
+# adds subdomain and .ipv6 subdomain for each language, eg: nl.example.com, nl.ipv6.example.com
+for language in $(echo "$LANGUAGES" | tr ',' ' '); do
+  subdomains="$subdomains,$language.$domain,$lanuge.ipv6.$domain"
+done
+
 if [ "$ENABLE_BATCH" != True ]; then
-  subdomains="$subdomains,conn.$domain,en.conn.$domain,nl.conn.$domain,conn.ipv6.$domain,en.conn.ipv6.$domain,nl.conn.ipv6.$domain"
+  subdomains="$subdomains,conn.$domain"
+  # adds connection test subdomains .conn and .conn.ipv6 subdomain for each language, eg:
+  # nl.conn.example.com, nl.conn.ipv6.example.com
+  for language in $(echo "$LANGUAGES" | tr ',' ' '); do
+    subdomains="$subdomains,$language.conn.$domain,$lanuage.conn.ipv6.$domain"
+  done
 fi
 if [ ! -z $REDIRECT_DOMAINS ];then
   subdomains="$subdomains,$REDIRECT_DOMAINS"

--- a/docker/webserver/nginx_templates/app.conf.template
+++ b/docker/webserver/nginx_templates/app.conf.template
@@ -231,15 +231,17 @@ server {
 
     # disable security.txt if branding is disabled
     set $internetnl_branding "${INTERNETNL_BRANDING}";
+    if ($internetnl_branding = "True"){
+      set $security_txt "/var/www/internet.nl/.well-known/security.txt";
+    }
+    if ($internetnl_branding != "True"){
+      set $security_txt "/var/www/internet.nl/.well-known/security-custom.txt";
+    }
     location = /.well-known/security.txt {
-      if ($internetnl_branding != "True"){
-        return 404;
-      }
       # basic auth should not apply to this path
       auth_basic off;
       # IP allowlist should also not apply
-      allow all;
-      alias /var/www/internet.nl/.well-known/security.txt;
+      alias $security_txt;
     }
 
     # static files served from Nginx container

--- a/docker/webserver/nginx_templates/app.conf.template
+++ b/docker/webserver/nginx_templates/app.conf.template
@@ -39,8 +39,8 @@ server {
     listen  [::]:80;
 
     http2 on;
-
-    server_name  ${INTERNETNL_DOMAINNAME} ~(nl|en|www|ipv6)\.${INTERNETNL_DOMAINNAME} ${REDIRECT_DOMAINS_LIST};
+    # LANGUAGES_REGEX is a list of language prefixes separated by pipes, eg: nl|en
+    server_name  ${INTERNETNL_DOMAINNAME} ~(${LANGUAGES_REGEX}|www|ipv6)\.${INTERNETNL_DOMAINNAME} ${REDIRECT_DOMAINS_LIST};
 
     # letsencrypt/ACME
     location /.well-known/acme-challenge/ {
@@ -63,7 +63,8 @@ server {
 
     http2 on;
 
-    server_name ~(conn|(?<subdomain>en\.|nl\.|www\.)conn).${INTERNETNL_DOMAINNAME};
+    # LANGUAGES_REGEX is a list of language prefixes separated by pipes, eg: nl|en
+    server_name ~(conn|(?<subdomain>(${LANGUAGES_REGEX}|www)\.)conn).${INTERNETNL_DOMAINNAME};
 
     # pass specific connection test paths to backend
     # /connection/
@@ -131,8 +132,8 @@ server {
     listen  [::]:443 ssl;
 
     http2 on;
-
-    server_name  www.${INTERNETNL_DOMAINNAME} ~(nl|en|conn)\.www.${INTERNETNL_DOMAINNAME} ${REDIRECT_DOMAINS_LIST};
+    # LANGUAGES_REGEX is a list of language prefixes separated by pipes, eg: nl|en
+    server_name  www.${INTERNETNL_DOMAINNAME} ~(${LANGUAGES_REGEX}|conn)\.www.${INTERNETNL_DOMAINNAME} ${REDIRECT_DOMAINS_LIST};
 
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
@@ -169,7 +170,8 @@ server {
 
     http2 on;
 
-    server_name  ${INTERNETNL_DOMAINNAME} ~(?<subdomain>nl\.|en\.|www\.|ipv6\.)${INTERNETNL_DOMAINNAME};
+    # LANGUAGES_REGEX is a list of language prefixes separated by pipes, eg: nl|en
+    server_name  ${INTERNETNL_DOMAINNAME} ~(?<subdomain>(${LANGUAGES_REGEX}|www|ipv6)\.)${INTERNETNL_DOMAINNAME};
 
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;

--- a/documentation/Customize.md
+++ b/documentation/Customize.md
@@ -3,21 +3,24 @@
 The Internet.nl tool has the ability to be customized for additional
 translations and content.
 
+## Development setup
+
+By default the repository is configured to show Internet.nl content during development and will not show some of the content you create for your fork. To show 'custom' content add the following to the `docker/local.env` file in your repository: `INTERNETNL_BRANDING=False`.
+
+For deployments the default for `INTERNETNL_BRANDING` is `False` so you should not have to add this.
 
 ## Translations
 
 Translation files are available under `translations/<locale>`.
 
-The available files are:
-- `main.po`, all the necessary strings to make internet.nl work;
-- `news.po`, all the news/blog entries.
-
 You can add new locales by creating a new folder under `translations` and
-adding the above files.
+adding `main.po`, with all the necessary strings to make internet.nl work;
 
 You need to translate all the strings in `main.po`.
 
-To add a new menu entry for a new language set the `LANGUAGES` setting in `local.env`. The default is `nl,en`. You can add new languages by adding languages codes supported by Django:
+Content specific to Internet.nl is not rendered in forked deployments. Some content (like news, about, footer, privacy, disclosure) can be added using a `custom.po` file. See the `translations/en/custom.po.dist` file for the translation strings that can be used. Rename this file to `custom.po` and add it for all locales you like to support.
+
+To add a new menu entry for a new language set the `LANGUAGES` setting in `docker/local.env` on your development repository adn deployment. The default is `nl,en`. You can add new languages by adding languages codes supported by Django:
 - https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-LANGUAGE_CODE
 - http://www.i18nguy.com/unicode/language-identifiers.html
 

--- a/documentation/Customize.md
+++ b/documentation/Customize.md
@@ -40,13 +40,16 @@ where [lang] is the language code added to LANGUAGE.
 
 You can remove languages you don't intend to support.
 
-
-
 Then, update the site using the procedure in [documentation/Docker-forked.md](Docker-forked.md) to rebuild the front accordingly.
 
 For `news.po` you can provide your own news/blogs but you need to follow the
 existing conventions. (**FIXME**: this needs further clarification)
 
+## Security.txt
+
+To add a `.well-known/security.txt` file to your installation, create the file `.well-known/security-custom.txt` in the repository. The existing `.well-known/security.txt` file cannot be used.
+
+After which the `webserver` image should be rebuild and will serve the file under the `/.well-known/security.txt` path.
 
 ## Scores
 

--- a/documentation/Customize.md
+++ b/documentation/Customize.md
@@ -17,13 +17,17 @@ adding the above files.
 
 You need to translate all the strings in `main.po`.
 
-To add a new meny entry for the new language:
-* add the language to `internet.nl/settings.py`
-* update `webserver/nginx_templates/app.conf.template` to include the language
-* update `docker/webserver/certbot.sh` to request LE certs for the new subdomain
+To add a new menu entry for a new language set the `LANGUAGES` setting in `local.env`. The default is `nl,en`. You can add new languages by adding languages codes supported by Django:
+- https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-LANGUAGE_CODE
+- http://www.i18nguy.com/unicode/language-identifiers.html
 
-This presumes you
-have the corresponding DNS entries already created, such as
+The first language in the list is the default langauge.
+
+So to add French and use it as the default languages set it to:
+
+    LANGUAGES=fr,nl,en
+
+This presumes you have the corresponding DNS entries already created, such as
 
 ```
 [lang].example.nl
@@ -32,7 +36,11 @@ have the corresponding DNS entries already created, such as
 [lang].conn.ipv6.example.nl
 ```
 
-where [lang] is the 2 letter ISO 639-1 language code.
+where [lang] is the language code added to LANGUAGE.
+
+You can remove languages you don't intend to support.
+
+
 
 Then, update the site using the procedure in [documentation/Docker-forked.md](Docker-forked.md) to rebuild the front accordingly.
 

--- a/integration_tests/common/test_basic.py
+++ b/integration_tests/common/test_basic.py
@@ -4,9 +4,13 @@ import pytest
 import requests
 from playwright.sync_api import expect
 import socket
+import os
 
 FOOTER_TEXT_EN = "Internet.nl is an initiative of the Internet community and the Dutch"
 FOOTER_TEXT_NL = "Internet.nl is een initiatief van de internetgemeenschap en de Nederlandse"
+
+LANGUAGE_CHANGE_TEXT_EN = "Test your website"
+LANGUAGE_CHANGE_TEXT_NL = "Test je website"
 
 SECURITY_TXT_TEXT = "Policy: https://internet.nl/disclosure/"
 
@@ -15,6 +19,8 @@ ROBOTS_TXT_TEXT = "Disallow: /site/"
 WELL_KNOWN_EXTERNAL_DOMAIN = "example.nl"
 WELL_KNOWN_EXTERNAL_IP = "94.198.159.35"
 WELL_KNOWN_EXTERNAL_IPV6 = "2a00:d78:0:712:94:198:159:35"
+
+INTERNETNL_BRANDING = os.environ.get("INTERNETNL_BRANDING")
 
 
 def test_sanity_no_external_dns():
@@ -48,6 +54,7 @@ def test_index_http_ok(page, app_url_subdomain):
     expect(response).to_be_ok()
 
 
+@pytest.mark.skipif(not INTERNETNL_BRANDING, reason="internet.nl branding not enabled")
 @pytest.mark.parametrize(
     ("app_url", "footer_text"),
     [("https://en.internet.test", FOOTER_TEXT_EN), ("https://nl.internet.test", FOOTER_TEXT_NL)],
@@ -59,6 +66,7 @@ def test_index_footer_text_present(page, app_url, footer_text):
     assert footer_text in footer.text_content()
 
 
+@pytest.mark.skipif(not INTERNETNL_BRANDING, reason="internet.nl branding not enabled")
 def test_security_txt(page, app_url_subdomain):
     page.goto(app_url_subdomain + "/.well-known/security.txt")
 
@@ -174,7 +182,7 @@ def test_conn_over_https_no_hsts(app_domain):
 
 @pytest.mark.parametrize(
     ("from_language", "button_text", "to_language", "footer_text"),
-    [("nl", "English", "en", FOOTER_TEXT_EN), ("en", "Nederlands", "nl", FOOTER_TEXT_NL)],
+    [("nl", "English", "en", LANGUAGE_CHANGE_TEXT_EN), ("en", "Nederlands", "nl", LANGUAGE_CHANGE_TEXT_NL)],
 )
 def test_change_language(page, app_domain, from_language, button_text, to_language, footer_text):
     """Test clicking the language change button."""
@@ -183,13 +191,13 @@ def test_change_language(page, app_domain, from_language, button_text, to_langua
     page.locator(f'#language-switch-header-container button:text("{button_text}")').click()
     page.wait_for_url(f"https://{to_language}.internet.test/")
 
-    footer = page.locator("#footer")
+    footer = page.locator("#content")
     assert footer_text in footer.text_content()
 
 
 @pytest.mark.parametrize(
     ("language", "footer_text"),
-    [("en", FOOTER_TEXT_EN), ("nl", FOOTER_TEXT_NL)],
+    [("en", LANGUAGE_CHANGE_TEXT_EN), ("nl", LANGUAGE_CHANGE_TEXT_NL)],
 )
 def test_accept_language_header(page, app_domain, language, footer_text):
     """Browser preferred language should be respected."""
@@ -197,7 +205,7 @@ def test_accept_language_header(page, app_domain, language, footer_text):
     page.set_extra_http_headers({"Accept-Language": language})
     page.goto(f"https://{app_domain}")
 
-    footer = page.locator("#footer")
+    footer = page.locator("#content")
     assert footer_text in footer.text_content()
 
 

--- a/interface/templates/about.html
+++ b/interface/templates/about.html
@@ -1,15 +1,24 @@
 {% extends "base.html" %}
 {% load static %}
+{% load translate %}
 
 {% block maincontent %}
   <article class="block wide">
     <section>
+      {% if "INTERNETNL_BRANDING"|get_settings_value %}
       {% include "content.html" with name="about content" %}
+      {% else %}
+      {% include "content.html" with name="about content custom" %}
+      {% endif %}
     </section>
   </article>
   <aside>
     <section class="block">
+      {% if "INTERNETNL_BRANDING"|get_settings_value %}
       {% include "content.html" with name="about contact" %}
+      {% else %}
+      {% include "content.html" with name="about contact custom" %}
+      {% endif %}
     </section>
   </aside>
 {% endblock %}

--- a/interface/templates/base.html
+++ b/interface/templates/base.html
@@ -72,13 +72,13 @@
       <nav id="sitenav">
         <ul>
           <li class="{% if pagemenu == 'home' %}current{% endif %}"><a href="/">{% include "string.html" with name="base home" %}</a></li>
-          {% if "INTERNETNL_BRANDING"|get_settings_value %}
           <li class="{% if pagemenu == 'news' %}current{% endif %}"><a href="/news/">{% include "string.html" with name="base news" %}</a></li>
-          {% endif %}
           <li class="{% if pagemenu == 'faqs' %}current{% endif %}"><a href="/faqs/">{% include "string.html" with name="base faqs" %}</a></li>
           <li class="{% if pagemenu == 'halloffame' %}current{% endif %}"><a href="/halloffame/">{% include "string.html" with name="base halloffame" %}</a></li>
           {% if "INTERNETNL_BRANDING"|get_settings_value %}
           <li class="{% if pagemenu == 'about' %}current{% endif %}"><a href="/about/">{% include "string.html" with name="base about" %}</a></li>
+          {% else %}
+          <li class="{% if pagemenu == 'about' %}current{% endif %}"><a href="/about/">{% include "string.html" with name="base about custom" %}</a></li>
           {% endif %}
         </ul>
       </nav>
@@ -101,14 +101,14 @@
     <div class="wrap">
       {% if "INTERNETNL_BRANDING"|get_settings_value %}
       {% include "string.html" with name="base info" %}
+      {% else %}
+      {% include "string.html" with name="base info custom" %}
       {% endif %}
       <div class="version">v{{ "VERSION"|get_settings_value }}</div>
       <hr>
       <ul>
-        {% if "INTERNETNL_BRANDING"|get_settings_value %}
         <li><a class="footlink" href="/disclosure/">{% include "string.html" with name="base disclosure" %}</a></li>
         <li><a class="footlink" href="/privacy/">{% include "string.html" with name="base privacy" %}</a></li>
-        {% endif %}
         <li><a class="footlink" href="/copyright/">{% include "string.html" with name="base copyright" %}</a></li>
         {% if "HAS_ACCESSIBILITY_PAGE"|get_settings_value %}
         <li><a class="footlink" href="/accessibility/">{% include "string.html" with name="base accessibility" %}</a></li>

--- a/interface/templates/disclosure.html
+++ b/interface/templates/disclosure.html
@@ -1,12 +1,21 @@
 {% extends "base.html" %}
+{% load translate %}
 
 {% block maincontent %}
   <article class="block wide">
+    {% if "INTERNETNL_BRANDING"|get_settings_value %}
     {% include "content.html" with name="disclosure content" %}
+    {% else %}
+    {% include "content.html" with name="disclosure content custom" %}
+    {% endif %}
   </article>
   <aside>
     <section class="block">
+      {% if "INTERNETNL_BRANDING"|get_settings_value %}
       {% include "content.html" with name="about contact" %}
+      {% else %}
+      {% include "content.html" with name="about contact custom" %}
+      {% endif %}
     </section>
   </aside>
 {% endblock %}

--- a/interface/templates/index.html
+++ b/interface/templates/index.html
@@ -74,7 +74,6 @@
 
 {% block maincontent %}
       <section class="block news">
-        {% if "INTERNETNL_BRANDING"|get_settings_value %}
         <h2>{% include "string.html" with name="base news" %}</h2>
         <ul>
         {% for article in articles %}
@@ -85,7 +84,6 @@
         {% endfor %}
         </ul>
         <p class="read-more"><a href="/articles/">{% include "string.html" with name="base newslink" %}</a></p>
-        {% endif %}
       </section>
       <section class="block hall-of-fame">
         <h2>{% include "string.html" with name="base halloffame" %}</h2>

--- a/interface/templates/privacy.html
+++ b/interface/templates/privacy.html
@@ -1,7 +1,12 @@
 {% extends "base.html" %}
+{% load translate %}
 
 {% block maincontent %}
   <article class="block wide">
+    {% if "INTERNETNL_BRANDING"|get_settings_value %}
     {% include "content.html" with name="privacy content" %}
+    {% else %}
+    {% include "content.html" with name="privacy content custom" %}
+    {% endif %}
   </article>
 {% endblock %}

--- a/interface/urls.py
+++ b/interface/urls.py
@@ -60,23 +60,19 @@ urlpatterns = [
     re_path(r"^mail/(?P<mailaddr>.*)/results$", mail.validate_domain),
     re_path(rf"^clear/{regex_dname}/$", views.clear),
     path("change_language/", views.change_language, name="change_language"),
+    path("contact/", views.indexpage),
+    path("blogs/", views.blogindexpage),
+    re_path(r"^blogs/(?P<addr>[a-zA-Z0-9\-]{1,40})/$", views.blogarticlepage),
+    re_path(r"^blogs/(?P<author>[a-zA-Z0-9\-]{1,40})/(?P<article>[a-zA-Z0-9\-]{1,80})/$", views.blogarticlepage),
+    path("news/", views.newsindexpage),
+    re_path(r"^news/(?P<article>[a-zA-Z0-9\-]{1,80})/$", views.newsarticlepage),
+    path("articles/", views.articleindexpage),
+    path("article/", views.articlespage),
+    re_path(r"^article/(?P<article>[a-zA-Z0-9\.\-]{1,80})/$", views.articlepage),
+    path("about/", views.aboutpage),
+    path("disclosure/", views.disclosurepage),
+    path("privacy/", views.privacypage),
 ]
-
-if settings.INTERNETNL_BRANDING:
-    urlpatterns += [
-        path("contact/", views.indexpage),
-        path("blogs/", views.blogindexpage),
-        re_path(r"^blogs/(?P<addr>[a-zA-Z0-9\-]{1,40})/$", views.blogarticlepage),
-        re_path(r"^blogs/(?P<author>[a-zA-Z0-9\-]{1,40})/(?P<article>[a-zA-Z0-9\-]{1,80})/$", views.blogarticlepage),
-        path("news/", views.newsindexpage),
-        re_path(r"^news/(?P<article>[a-zA-Z0-9\-]{1,80})/$", views.newsarticlepage),
-        path("articles/", views.articleindexpage),
-        path("article/", views.articlespage),
-        re_path(r"^article/(?P<article>[a-zA-Z0-9\.\-]{1,80})/$", views.articlepage),
-        path("about/", views.aboutpage),
-        path("disclosure/", views.disclosurepage),
-        path("privacy/", views.privacypage),
-    ]
 
 # Host-urls that are accessible by host-only, which should be approachable by developers as well during
 # development (although your DNS is probably not set correctly to deal with the tests.

--- a/interface/views/__init__.py
+++ b/interface/views/__init__.py
@@ -30,7 +30,10 @@ def page404(request, exception):
 
 @simple_cache_page
 def indexpage(request):
-    articles = _("article .index").split()
+    if settings.INTERNETNL_BRANDING:
+        articles = _("article .index").split()
+    else:
+        articles = _("article custom .index").split()
     articles = articles[0:6]
     cache_id = redis_id.home_stats_data.id
     novalue = "…"
@@ -173,13 +176,19 @@ def newsarticlepage(request, article):
 
 
 def articlespage(request):
-    articles = _("article .index").split()
+    if settings.INTERNETNL_BRANDING:
+        articles = _("article .index").split()
+    else:
+        articles = _("article custom .index").split()
     article = articles[0]
     return redirect("/article/" + article)
 
 
 def articleindexpage(request):
-    articles = _("article .index").split()
+    if settings.INTERNETNL_BRANDING:
+        articles = _("article .index").split()
+    else:
+        articles = _("article custom .index").split()
     if len(articles) < 1:
         articles = []
     return render(
@@ -195,7 +204,10 @@ def articlepage(request, article):
     if _(title) == title:
         return page404(request, None)
 
-    articles = _("article .index").split()
+    if settings.INTERNETNL_BRANDING:
+        articles = _("article .index").split()
+    else:
+        articles = _("article custom .index").split()
     articles = articles[0:6]
     date = "article " + article + " date"
     lead = "article " + article + " lead"

--- a/internetnl/settings.py
+++ b/internetnl/settings.py
@@ -266,21 +266,16 @@ CACHE_RESET_ALLOWLIST = os.getenv("INTERNETNL_CACHE_RESET_ALLOWLIST", "").split(
 #
 # Internationalization and Locatization fixed to dutch at this time.
 # A single installation will only server one target audience.
-LANGUAGE_CODE = "en"
 USE_I18N = True
 USE_L10N = False
 USE_TZ = True
 
 # Supported languages.
-# NOTE: Make sure that a DNS record for each language exists.
-#       More information can be found in the README file.
-LANGUAGES = sorted(
-    [
-        ("nl", "Dutch"),
-        ("en", "English"),
-    ],
-    key=lambda x: x[0],
-)
+# Read languages passed in from .env files. See documentation/Customize.md
+LANGUAGES = [(landcode, "") for landcode in os.getenv("LANGUAGES", "nl,en").split(",")]
+
+# set the default language to first language in the list
+LANGUAGE_CODE = LANGUAGES[0][0]
 
 # --- Static files (CSS, JavaScript, Images)
 #     https://docs.djangoproject.com/en/1.11/howto/static-files/

--- a/translations/en/custom.po.dist
+++ b/translations/en/custom.po.dist
@@ -1,0 +1,50 @@
+msgid "base about custom"
+msgstr "About custom"
+
+msgid "base info custom"
+msgstr "About this website"
+
+msgid "about content custom"
+msgstr "Some about content"
+
+msgid "about contact custom"
+msgstr ""
+"# About custom\n"
+"## Email\n"
+"custom@example.com\n"
+
+msgid "privacy content custom"
+msgstr ""
+"# Privacy statement\n"
+"\n"
+"*Revised 24th of October 2023*\n"
+
+msgid "article custom .index"
+msgstr ""
+"hello-world\n"
+"lorum-ipsum\n"
+
+msgid "article hello-world date"
+msgstr "22 March 2023"
+
+msgid "article hello-world lead"
+msgstr ""
+"Hello world?"
+
+msgid "article hello-world title"
+msgstr "Hello World!"
+
+msgid "article hello-world body"
+msgstr "Hello World!"
+
+msgid "article lorum-ipsum date"
+msgstr "1 January 2024"
+
+msgid "article lorum-ipsum lead"
+msgstr "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
+
+msgid "article lorum-ipsum title"
+msgstr "Lorum ipsum"
+
+msgid "article lorum-ipsum body"
+msgstr "Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui."


### PR DESCRIPTION
This PR adds options to more easily configure the language selection menu and things like subdomains, certificates related to translations. As well as options to customize the security.txt file and some content like news, about page, footer, disclosure, privacy, without having forked deployments default to Internet.nl branded content.