### PR TITLE
Fix #1453 - Update sectxt to 0.9.4 from github release

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -37,7 +37,6 @@ chardet
 requests
 hiredis
 ip_address
-sectxt
 colorlog
 setuptools_scm
 sentry-sdk
@@ -60,6 +59,10 @@ whitenoise
 
 # Needed in celery/kombu, but not installed automatically?
 cached-property
+
+# sectxt from github, as the 0.9.4 on pypi can not refer to the fixed version of pgpy
+# can be fixed when https://github.com/SecurityInnovation/PGPy/pull/467 is merged and a new sectxt is released
+https://github.com/DigitalTrustCenter/sectxt/archive/refs/tags/0.9.4.tar.gz
 
 # our custom fork
 https://github.com/internetstandards/python-whois/releases/download/v1.0.0/pythonwhois-internet.nl-1.0.0.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -171,7 +171,7 @@ requests==2.32.0
     #   sectxt
 rjsmin==1.2.1
     # via -r requirements.in
-sectxt==0.9.3
+sectxt @ https://github.com/DigitalTrustCenter/sectxt/archive/refs/tags/0.9.4.tar.gz
     # via -r requirements.in
 selenium==3.141.0
     # via -r requirements.in
@@ -222,6 +222,8 @@ urllib3==2.0.7
     #   sentry-sdk
 uwsgi==2.0.22
     # via -r requirements.in
+validators==0.23.0
+    # via sectxt
 vine==5.0.0
     # via
     #   amqp


### PR DESCRIPTION
We depend on https://github.com/SecurityInnovation/PGPy/pull/467 and
sectxt's pypi release can not point to that, only to other pypi
releases. Hence, pull sectxt from github now.

I have manually verified that the tarball we pull for sectxt, has only one reference to a pgpy dependency, which in turn points to a zip that contains the regex fix.