### PR TITLE
Set worker stop_grace_period to 10m to prevent task kill during worker restart

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -245,6 +245,9 @@ services:
     entrypoint: /entrypoint-worker.sh
     command: celery --app internetnl worker --without-gossip --pool=eventlet --time-limit=300 --concurrency=$WORKER_CONCURRENCY
       --queues default,celery,db_worker,ipv6_worker,mail_worker,web_worker,resolv_worker,dnssec_worker,rpki_worker,batch_main,batch_callback,batch_scheduler
+    # time after which a SIGKILL is sent to celery after a SIGTERM (warm shutdown), default 10s
+    # insufficient short grace period causes issues on batch when tasks are killed during the hourly worker restart
+    stop_grace_period: 10m
 
     depends_on:
       db-migrate:


### PR DESCRIPTION
Batch is not resistent to tasks being killed, and workers get periodic restarts to reduce impact of memory leaks.
We might get away with just 5 minutes, but the harm of too low is larger than the harm of too high.