### PR TITLE
Fix #1474 check for URI scheme in DMARC parser, add tests for DMARC parser

### DIFF
--- a/checks/tasks/dmarc_parser.py
+++ b/checks/tasks/dmarc_parser.py
@@ -74,9 +74,11 @@ def _check_dmarc_uri(tokens):
         uri, numeric = uri.split("!")
         dmarc_uri_numeric.parseString(numeric)
     try:
-        urlparse(uri)
+        parsed_url = urlparse(uri)
     except ValueError:
         raise ParseException("Could not parse URI.")
+    if parsed_url.scheme == "":
+        raise ParseException("URI scheme is missing (mailto:).")
     return None
 
 

--- a/checks/test/test_dmarc_parser.py
+++ b/checks/test/test_dmarc_parser.py
@@ -1,0 +1,30 @@
+# Copyright: 2024, ECP, NLnet Labs and the Internet.nl contributors
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from pyparsing import ParseException
+
+from checks.tasks.dmarc_parser import _check_dmarc_uri, parse
+
+
+def test__check_dmarc_uri():
+    """
+    Check if None is returned on valid URI
+    """
+    assert _check_dmarc_uri(["mailto:test@example.com"]) is None
+
+
+def test__check_dmarc_uri_detect_missing_uri_scheme():
+    """
+    Many people forget to add the mailto: scheme to their DMARC URI.
+    This common error should be detected.
+    """
+    with pytest.raises(ParseException):
+        _check_dmarc_uri(["test@example.com"])
+
+
+def test_parse():
+    sample_record = "v=DMARC1; p=none; rua=mailto:dmarc@example.com"
+    result = parse(sample_record)
+    assert result.version == "v=DMARC1"
+    assert result.directives.request == "p=none"
+    assert result.directives.auri == "rua=mailto:dmarc@example.com"


### PR DESCRIPTION
This PR adds a check if a DMARC policy has a common error where the `rua` is missing the scheme of the target URL:

- wrong: rua=dmarc-reports@example.com
- correct: rua=mailto:dmarc-reports@example.com

Also adds some unit tests for the DMARC parsing subroutines. 

See bug #1474 