### PR TITLE
Refs #1510: resets path variable so legacy path error is used

### DIFF
--- a/checks/tasks/securitytxt.py
+++ b/checks/tasks/securitytxt.py
@@ -46,6 +46,8 @@ def _retrieve_securitytxt(af_ip_pair, hostname: str, task: SetupUnboundContext) 
         if response.status_code != 200:
             http_kwargs["path"] = SECURITYTXT_LEGACY_PATH
             response = http_get_ip(**http_kwargs)
+            if response.status_code == 200:
+                path = SECURITYTXT_LEGACY_PATH
         if response.history:
             found_host = urlparse(response.url).hostname
         else:


### PR DESCRIPTION
When using the legacy security.txt location only, the SecuritytxtRetrieveResult accidentally still contained the .well-known path. This PR fixed this by resetting the path variable if the legacy path is used and the .well-known path is not.

This will not change anything when both the .well-known AND the legacy path are used (even when the legacy path contains a different security.txt) as is discussed in #1510 as well. It could be argued that this is according to the [spec](https://www.rfc-editor.org/rfc/rfc9116#name-location-of-the-securitytxt): 

> If a "security.txt" file is present in both locations, the one in the "/.well-known/" path MUST be used.

But we could also argue that this is such bad practice that we want to provide an error for that later.