### PR TITLE
Remove not needed CSRF token

### DIFF
--- a/interface/templates/base.html
+++ b/interface/templates/base.html
@@ -56,7 +56,6 @@
             <button class="active-language" disabled>{{lang.name_local}}</button>
           {% else %}
             <form action="/change_language/" method="post">
-            {% csrf_token %}
               <input type="hidden" name="previous-page" value="{{request.path}}"/>
               <input type="hidden" name="language" value="{{language.0}}"/>
               <button>{{lang.name_local}}</button>

--- a/internetnl/internet.nl.dist.env
+++ b/internetnl/internet.nl.dist.env
@@ -20,12 +20,6 @@ export SECRET_KEY=secret
 export DJANGO_IS_PROXIED=True
 ### CSV String, the IPV6_TEST_ADDR is automatically added
 export ALLOWED_HOSTS=.internet.nl,internet.nl
-### String
-export ADMIN_NAME=Administrator
-### String, e-mail address
-export ADMIN_EMAIL=django@internet.nl
-### String, e-mail address
-export SERVER_EMAIL=django@internet.nl
 ### CSV String
 export INTERNAL_IPS="localhost,127.0.0.1"
 ### String

--- a/internetnl/settings.py
+++ b/internetnl/settings.py
@@ -47,9 +47,6 @@ SKIP_SECRET_KEY_CHECK = bool(getenv("SKIP_SECRET_KEY_CHECK", DEBUG))
 # # and the option to Preserve the Host are set by your proxy.
 DJANGO_IS_PROXIED = get_boolean_env("DJANGO_IS_PROXIED", False)
 ALLOWED_HOSTS = split_csv_trim(getenv("ALLOWED_HOSTS", ".internet.nl, internet.nl"))
-ADMIN_NAME = getenv("ADMIN_NAME", "Administrator")
-ADMIN_EMAIL = getenv("ADMIN_EMAIL", "Administrator")
-SERVER_EMAIL = getenv("SERVER_EMAIL", "django@internet.nl")
 INTERNAL_IPS = split_csv_trim(getenv("INTERNAL_IPS", ""))
 TIME_ZONE = getenv("TIME_ZONE", "UTC")
 
@@ -135,11 +132,7 @@ else:
 ALLOWED_HOSTS = ALLOWED_HOSTS + [IPV6_TEST_ADDR, f"[{IPV6_TEST_ADDR}]"]
 
 INSTALLED_APPS = [
-    "django.contrib.admin",
-    "django.contrib.auth",
     "django.contrib.contenttypes",
-    "django.contrib.sessions",
-    "django.contrib.messages",
     "django.contrib.staticfiles",
     "django_bleach",
     "markdown_deux",
@@ -156,13 +149,11 @@ TEMPLATES = [
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
-                "django.contrib.auth.context_processors.auth",
                 "django.template.context_processors.debug",
                 "django.template.context_processors.i18n",
                 "django.template.context_processors.media",
                 "django.template.context_processors.static",
                 "django.template.context_processors.tz",
-                "django.contrib.messages.context_processors.messages",
                 "django.template.context_processors.request",
             ],
             "libraries": {"translate": "interface.templatetags.translate"},
@@ -178,15 +169,11 @@ MIDDLEWARE = [
     "django_statsd.middleware.GraphiteRequestTimingMiddleware",
     "django_statsd.middleware.GraphiteMiddleware",
     "django_hosts.middleware.HostsRequestMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.messages.middleware.MessageMiddleware",
     "django_hosts.middleware.HostsResponseMiddleware",
     "internetnl.custom_middlewares.ActivateTranslationMiddleware",
 ]
 
-ADMINS = ((ADMIN_NAME, ADMIN_EMAIL),)
 ROOT_URLCONF = "internetnl.urls"
 ROOT_HOSTCONF = "internetnl.hosts"
 DEFAULT_HOST = "www"

--- a/internetnl/urls.py
+++ b/internetnl/urls.py
@@ -1,15 +1,8 @@
 # Copyright: 2022, ECP, NLnet Labs and the Internet.nl contributors
 # SPDX-License-Identifier: Apache-2.0
-from django.conf import settings
-from django.urls import include, path, re_path
-from django.contrib import admin
+from django.urls import include, path
 
 urlpatterns = [
     path("", include("interface.urls")),
 ]
 handler404 = "interface.views.page404"
-
-if settings.DEBUG is True:
-    urlpatterns += [
-        re_path(r"^admin/", admin.site.urls),
-    ]


### PR DESCRIPTION
For `/change_language/` the result is only a Location redirect (no session/cookie state), therefore there is no need for a CRSF token.
- Fix #1581.