### PR TITLE
Typo correction in docker command

### DIFF
--- a/documentation/Docker-deployment.md
+++ b/documentation/Docker-deployment.md
@@ -317,7 +317,7 @@ By default the installation will try to request a HTTPS certificate with Letsenc
 
 and
 
-    docker compose --project-name=internetnl-prod exec webserver "cat /var/log/letsencrypt/letsencrypt.log"
+    docker compose --project-name=internetnl-prod exec webserver cat /var/log/letsencrypt/letsencrypt.log
 
 It may take a few minutes after starting for the Letsencrypt certificates to be registered and loaded.
 


### PR DESCRIPTION
Very small typo correction since if you execute `docker compose --project-name=internetnl-prod exec webserver "cat /var/log/letsencrypt/letsencrypt.log"` you will get:

`OCI runtime exec failed: exec failed: unable to start container process: exec: "cat /var/log/letsencrypt/letsencrypt.log": stat cat /var/log/letsencrypt/letsencrypt.log: no such file or directory: unknown`

Hence quotes need to be discarded.