### PR TITLE
Make as many as possible containers run native on Apple Silicon

### DIFF
--- a/docker/compose.build.yaml
+++ b/docker/compose.build.yaml
@@ -9,48 +9,81 @@ services:
       context: ..
       dockerfile: docker/Dockerfile
       target: app
+      platforms:
+        # required because current version of nassl cannot be compile for ARM (eg: Apple Silicon)
+        - "linux/amd64"
 
   db-migrate:
     build:
       context: ..
       dockerfile: docker/Dockerfile
       target: app
+      platforms:
+        # required because current version of nassl cannot be compile for ARM (eg: Apple Silicon)
+        - "linux/amd64"
 
   worker: &worker
     build:
       context: ..
       dockerfile: docker/Dockerfile
       target: app
+      platforms:
+        # required because current version of nassl cannot be compile for ARM (eg: Apple Silicon)
+        - "linux/amd64"
 
   worker-nassl:
-    <<: *worker
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      target: app
+      platforms:
+        # required because current version of nassl cannot be compile for ARM (eg: Apple Silicon)
+        - "linux/amd64"
 
   worker-slow:
-    <<: *worker
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      target: app
+      platforms:
+        # required because current version of nassl cannot be compile for ARM (eg: Apple Silicon)
+        - "linux/amd64"
 
   beat:
     build:
       context: ..
       dockerfile: docker/Dockerfile
       target: app
+      platforms:
+        # required because current version of nassl cannot be compile for ARM (eg: Apple Silicon)
+        - "linux/amd64"
 
   unbound:
     build:
       context: ..
       dockerfile: docker/Dockerfile
       target: unbound
+      platforms:
+        # required because current version of nassl cannot be compile for ARM (eg: Apple Silicon)
+        - "linux/amd64"
 
   resolver-permissive:
     build:
       context: ..
       dockerfile: docker/Dockerfile
       target: unbound
+      platforms:
+        # required because current version of nassl cannot be compile for ARM (eg: Apple Silicon)
+        - "linux/amd64"
 
   resolver-validating:
     build:
       context: ..
       dockerfile: docker/Dockerfile
       target: unbound
+      platforms:
+        # required because current version of nassl cannot be compile for ARM (eg: Apple Silicon)
+        - "linux/amd64"
 
   cron:
     build:
@@ -74,6 +107,9 @@ services:
       target: linttest
       args:
         RELEASE: 0.0.0-dev0
+      platforms:
+        # required because current version of nassl cannot be compile for ARM (eg: Apple Silicon)
+        - "linux/amd64"
 
   test-runner:
     build:
@@ -97,9 +133,15 @@ services:
       target: linttest
       args:
         RELEASE: 0.0.0-dev0
+      platforms:
+        # required because current version of nassl cannot be compile for ARM (eg: Apple Silicon)
+        - "linux/amd64"
 
   mock-resolver:
     build:
       context: ..
       dockerfile: docker/Dockerfile
       target: unbound
+      platforms:
+        # required because current version of nassl cannot be compile for ARM (eg: Apple Silicon)
+        - "linux/amd64"

--- a/docker/compose.integration-tests.yaml
+++ b/docker/compose.integration-tests.yaml
@@ -61,6 +61,8 @@ services:
         condition: service_healthy
       worker-slow:
         condition: service_healthy
+      worker-nassl:
+        condition: service_healthy
       unbound:
         condition: service_healthy
         required: false

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -325,6 +325,8 @@ services:
       --queues nassl_worker,batch_nassl
     # set hostname for Sentry
     hostname: worker-nassl
+    # required because current version of nassl cannot be compile for ARM (eg: Apple Silicon)
+    platform: linux/amd64
 
   # worker for slow and long running tasks that could require a lot of memory (eg: hof update)
   worker-slow:
@@ -406,7 +408,7 @@ services:
       - SENTRY_ENVIRONMENT
       - SENTRY_SERVER_NAME
     healthcheck:
-      test: ["CMD", "pgrep", "celery"]
+      test: ["CMD", "pgrep", "-f", "celery"]
       interval: $HEALTHCHECK_INTERVAL
       # TODO: waiting for: https://github.com/docker/compose/issues/10830
       # start_interval: 5s


### PR DESCRIPTION
This PR improves build/runtime on Apple Silicon by using as much as possible native containers images for ARM.

# Building

Clean build:
- `darwin/amd64` (core i5, native) `time make build-no-cache`: `339.94s`
- `darwin/amd64` (m4, emulated) `time DOCKER_DEFAULT_PLATFORM=linux/amd64 make build-no-cache`: `584.05s`
- `darwin/arm64` (m4, native+emulated) `time make build-no-cache`: `600.39s`
- `darwin/arm64` (m1, native+emulated) `time make build-no-cache`: `917.0s`

Cached rebuild:
- `darwin/amd64` (core i5, native) `make build; time make build`: `36.16s`
- `darwin/amd64` (m4, emulated) `DOCKER_DEFAULT_PLATFORM=linux/amd64 make build; time DOCKER_DEFAULT_PLATFORM=linux/amd64 make build`: `5.92s`
- `darwin/arm64` (m4, native+emulated) `make build; time make build`: `6.08s`
- `darwin/arm64` (m1, native+emulated) `make build; time make build`: `10.73s`

# Testing

- darwin/amd64 (core i5, native) `make up env=test; time make integration-tests`: `77 passed, 12 skipped, 36 warnings in 63.31s (0:01:03)`, total time: `67.74s`


- darwin/amd64 (m4, emulated) `DOCKER_DEFAULT_PLATFORM=linux/amd64 make up env=test; time make integration-tests` `77 passed, 12 skipped, 36 warnings in 113.53s (0:01:53)`, total time: `116.83s`

- darwin/arm64 (m4, native+emulated) `make up env=test; time make integration-tests`: `77 passed, 12 skipped, 36 warnings in 41.95s`, total time: `44.96s`

- darwin/arm64 (m1, native+emulated) `make up env=test; time make integration-tests`: `77 passed, 12 skipped, 36 warnings in 48.78s`, total time: `52.18s`


# Notes

Verify container architecture: `docker ps -q | xargs -I% -n1 docker exec -i % arch`

Forcing `amd64` (`RELEASE=main` as `util` image is not available as `latest`: `DOCKER_DEFAULT_PLATFORM=linux/amd64 RELEASE=main make up env=test`
