### PR TITLE
Fix RPKI single IPv46

### DIFF
--- a/checks/tasks/rpki.py
+++ b/checks/tasks/rpki.py
@@ -122,8 +122,8 @@ def callback(results: Mapping[TestName, TestResult], domain, parent, parent_name
     return parent, results
 
 
-web_registered = check_registry("web_rpki", web_callback, shared.resolve_a_aaaa)
-batch_web_registered = check_registry("batch_web_rpki", batch_web_callback, shared.batch_resolve_a_aaaa)
+web_registered = check_registry("web_rpki", web_callback, shared.resolve_all_a_aaaa)
+batch_web_registered = check_registry("batch_web_rpki", batch_web_callback, shared.batch_resolve_all_a_aaaa)
 mail_registered = check_registry("mail_rpki", mail_callback, shared.resolve_mx)
 batch_mail_registered = check_registry("batch_mail_rpki", batch_mail_callback, shared.batch_resolve_mx)
 

--- a/checks/tasks/rpki.py
+++ b/checks/tasks/rpki.py
@@ -334,6 +334,7 @@ def generate_validity_report(subtestname, category, hostset) -> int:
     invalid_count = 0  # count of validation resulting in 'invalid'
     not_valid_count = 0  # count of validations not resulting in 'valid'
     tech_data = []
+    routes_shown_for_host = []
 
     prev_host = None
     for host in hostset:
@@ -346,9 +347,17 @@ def generate_validity_report(subtestname, category, hostset) -> int:
 
             for route, validity in ip["validity"].items():
                 asn, prefix = route
+
+                first_line_for_host = host.host != prev_host
+                if first_line_for_host:
+                    routes_shown_for_host = []
+                if route in routes_shown_for_host:
+                    continue
+                routes_shown_for_host.append(route)
+
                 tech_data.append(
                     gen_tech_data(
-                        host.host if host.host != prev_host else "...",
+                        host.host if first_line_for_host else "...",
                         asn,
                         prefix,
                         validity,

--- a/checks/tasks/shared.py
+++ b/checks/tasks/shared.py
@@ -204,7 +204,7 @@ def do_resolve_mx_ips(self, url, *args, **kwargs):
         if status is not MxStatus.has_mx:
             continue
 
-        af_ip_pairs = do_resolve_all_a_aaaa(self, url, *args, **kwargs)
+        af_ip_pairs = do_resolve_all_a_aaaa(self, qname, *args, **kwargs)
         mx_ips_pairs.append((qname, af_ip_pairs))
 
     return mx_ips_pairs


### PR DESCRIPTION
- Fixes #1592

Current state:
- [x] Webserver > Route Origin Authorisation existence 
    Webserver | IP address | RPKI Route Origin Authorization
    -- | -- | --
    rijksoverheid.nl | 178.22.85.8 | yes
    ... | 178.22.85.9 | yes
    ... | 178.22.85.10 | yes
    ... | 178.22.85.11 | yes
    ... | 2a00:d00:3:2::5 | yes
    ... | 2a00:d00:3:2::4 | yes
    ... | 2a00:d00:3:2::6 | yes
    ... | 2a00:d00:3:2::3 | yes
- [x] Webserver > Route announcement validity
  Initial pre de-duplication version:
    Web server | BGP Route Prefix | BGP Route Origin ASN | RPKI Origin Validation state
    -- | -- | -- | --
    rijksoverheid.nl | 178.22.80.0/21 | AS41887 | valid
    ... | 178.22.84.0/22 | AS41887 | valid
    ... | 178.22.80.0/21 | AS41887 | valid
    ... | 178.22.84.0/22 | AS41887 | valid
    ... | 178.22.80.0/21 | AS41887 | valid
    ... | 178.22.84.0/22 | AS41887 | valid
    ... | 178.22.80.0/21 | AS41887 | valid
    ... | 178.22.84.0/22 | AS41887 | valid
    ... | 2a00:d00::/32 | AS41887 | valid
    ... | 2a00:d00::/29 | AS41887 | valid
    ... | 2a00:d00::/32 | AS41887 | valid
    ... | 2a00:d00::/29 | AS41887 | valid
    ... | 2a00:d00::/32 | AS41887 | valid
    ... | 2a00:d00::/29 | AS41887 | valid
    ... | 2a00:d00::/32 | AS41887 | valid
    ... | 2a00:d00::/29 | AS41887 | valid
- [x] de-duplicate routes in Webserver > Route announcement validity tech table
    Web server | BGP Route Prefix | BGP Route Origin ASN | RPKI Origin Validation state
    -- | -- | -- | --
    rijksoverheid.nl | 178.22.84.0/22 | AS41887 | valid
    ... | 178.22.80.0/21 | AS41887 | valid
    ... | 2a00:d00::/29 | AS41887 | valid
    ... | 2a00:d00::/32 | AS41887 | valid
- [x] test: Name servers of domain > Route Origin Authorisation existence 
    Name server | IP address | RPKI Route Origin Authorization
    -- | -- | --
    ns3.cloudflare.com. | 162.159.7.226 | yes
    ... | 162.159.0.33 | yes
    ... | 2400:cb00:2049:1::a29f:7e2 | yes
    ... | 2400:cb00:2049:1::a29f:21 | yes
    ns4.cloudflare.com. | 162.159.8.55 | yes
    ... | 162.159.1.33 | yes
    ... | 2400:cb00:2049:1::a29f:837 | yes
    ... | 2400:cb00:2049:1::a29f:121 | yes
    ns5.cloudflare.com. | 162.159.2.9 | yes
    ... | 162.159.9.55 | yes
    ... | 2400:cb00:2049:1::a29f:937 | yes
    ... | 2400:cb00:2049:1::a29f:209 | yes
    ns6.cloudflare.com. | 162.159.5.6 | yes
    ... | 162.159.3.11 | yes
    ... | 2400:cb00:2049:1::a29f:506 | yes
    ... | 2400:cb00:2049:1::a29f:30b | yes
    ns7.cloudflare.com. | 162.159.6.6 | yes
    ... | 162.159.4.8 | yes
    ... | 2400:cb00:2049:1::a29f:606 | yes
    ... | 2400:cb00:2049:1::a29f:408 | yes
- [x] test: Name servers of domain > Route announcement validity
    Name server | BGP Route Prefix | BGP Route Origin ASN | RPKI Origin Validation state
    -- | -- | -- | --
    ns3.cloudflare.com. | 162.159.0.0/20 | AS13335 | valid
    ... | 162.159.7.0/24 | AS13335 | valid
    ... | 162.159.0.0/24 | AS13335 | valid
    ... | 2400:cb00:2049::/48 | AS13335 | valid
    ns4.cloudflare.com. | 162.159.8.0/24 | AS13335 | valid
    ... | 162.159.0.0/20 | AS13335 | valid
    ... | 162.159.1.0/24 | AS13335 | valid
    ... | 2400:cb00:2049::/48 | AS13335 | valid
    ns5.cloudflare.com. | 162.159.0.0/20 | AS13335 | valid
    ... | 162.159.2.0/24 | AS13335 | valid
    ... | 162.159.9.0/24 | AS13335 | valid
    ... | 2400:cb00:2049::/48 | AS13335 | valid
    ns6.cloudflare.com. | 162.159.5.0/24 | AS13335 | valid
    ... | 162.159.0.0/20 | AS13335 | valid
    ... | 162.159.3.0/24 | AS13335 | valid
    ... | 2400:cb00:2049::/48 | AS13335 | valid
    ns7.cloudflare.com. | 162.159.6.0/24 | AS13335 | valid
    ... | 162.159.0.0/20 | AS13335 | valid
    ... | 162.159.4.0/24 | AS13335 | valid
    ... | 2400:cb00:2049::/48 | AS13335 | valid
- [x] de-duplicate routes in Mail server(s) > Route announcement validity tech table
    Before ([see `fastmail.com` test report](https://internet.nl/mail/fastmail.com/1416805/#control-panel-35)):
    Mail server | BGP Route Prefix | BGP Route Origin ASN | RPKI Origin Validation state
    -- | -- | -- | --
    in1-smtp.messagingengine.com. | 103.168.172.0/24 | AS151847 | valid
    ... | 103.168.172.0/24 | AS151847 | valid
    ... | 103.168.172.0/24 | AS151847 | valid
    ... | 103.168.172.0/24 | AS151847 | valid
    ... | 103.168.172.0/24 | AS151847 | valid
    ... | 103.168.172.0/24 | AS151847 | valid
    ... | 103.168.172.0/24 | AS151847 | valid
    ... | 103.168.172.0/24 | AS151847 | valid
    in2-smtp.messagingengine.com. | 202.12.124.0/24 | AS151847 | valid
    ... | 202.12.124.0/24 | AS151847 | valid

    After:
    Mail server | BGP Route Prefix | BGP Route Origin ASN | RPKI Origin Validation state
    -- | -- | -- | --
    in1-smtp.messagingengine.com. | 103.168.172.0/24 | AS151847 | valid
    in2-smtp.messagingengine.com. | 202.12.124.0/24 | AS151847 | valid
