### PR TITLE
Fix fingerprint typo in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ help:
 	@echo '                                              Optional branch=x to use a specific content repo branch.'
 	@echo '   make frontend                              (re)generate CSS and Javascript'
 	@echo '   make update_padded_macs                    update padded MAC information'
-	@echo '   make update_cert_fingerprints              update certificate fingerpint information'
+	@echo '   make update_cert_fingerprints              update certificate fingerprint information'
 	@echo '   make update_root_key_file                  update DNS root key file'
 
 translations:


### PR DESCRIPTION
### What

- This PR fixes a typo (fingerprint) in makefile help.

### How to test

- Run `make` or `make help` and make sure "fingerprint" is spelled correctly .