### PR TITLE
Fix auto_update DOCKER_REGISTRY default

### DIFF
--- a/docker/cron-docker/periodic/15min/auto_update
+++ b/docker/cron-docker/periodic/15min/auto_update
@@ -33,6 +33,6 @@ docker run --pull=always --network none \
   --volume /var/run/docker.sock:/var/run/docker.sock \
   --volume $HOME/.docker:/root/.docker \
   --volume /opt/Internet.nl:/opt/Internet.nl \
-  --env "DOCKER_REGISTRY=$DOCKER_REGISTRY" \
-  "$DOCKER_REGISTRY/util:$UPSTREAM_RELEASE" \
+  --env "DOCKER_REGISTRY=${DOCKER_REGISTRY:-ghcr.io/internetstandards}" \
+  "${DOCKER_REGISTRY:-ghcr.io/internetstandards}/util:$UPSTREAM_RELEASE" \
   /deploy.sh


### PR DESCRIPTION
- Fixes #1601

Use `${DOCKER_REGISTRY:-ghcr.io/internetstandards}` instead of `$DOCKER_REGISTRY`.