### PR TITLE
Remove twitter link from footer

### DIFF
--- a/interface/templates/base.html
+++ b/interface/templates/base.html
@@ -114,7 +114,6 @@
         <li><a class="footlink" href="/accessibility/">{% include "string.html" with name="base accessibility" %}</a></li>
         {% endif %}
         {% if "INTERNETNL_BRANDING"|get_settings_value %}
-        <li class="follow-us"><a class="footlink twitterfollow" href="https://twitter.com/internet_nl">Twitter</a></li>
         <li class="follow-us"><a class="footlink linkedinfollow" href="https://www.linkedin.com/company/internet-nl/">LinkedIn</a></li>
         <li class="follow-us"><a class="footlink mastodonfollow" href="https://mastodon.nl/@internet_nl" rel="me">Mastodon</a></li>
         {% endif %}


### PR DESCRIPTION
This might leave a little CSS/images, but that'll get cleaned with the new design anyways, so not worth digging around for it.