### PR TITLE
Removed obsoleter container internetnl-prod-resolver-permissive-1

### DIFF
--- a/documentation/Docker-deployment.md
+++ b/documentation/Docker-deployment.md
@@ -370,7 +370,6 @@ To verify the health status of the critial services use these commands:
 	docker inspect --format='{{.State.Health.Status}}' internetnl-prod-rabbitmq-1|grep -qw healthy
 	docker inspect --format='{{.State.Health.Status}}' internetnl-prod-unbound-1|grep -qw healthy
 	docker inspect --format='{{.State.Health.Status}}' internetnl-prod-routinator-1|grep -qw healthy
-	docker inspect --format='{{.State.Health.Status}}' internetnl-prod-resolver-permissive-1|grep -qw healthy
 	docker inspect --format='{{.State.Health.Status}}' internetnl-prod-resolver-validating-1|grep -qw healthy
 
 The services `webserver`, `app`, `postgres` and `redis` are critical for the user facing HTTP frontend, no page will show if these are not running. The services `worker`, `rabbitmq`, `routinator`, `unbound` and `resolver-validating` are additionally required for new tests to be performed. The `beat` service is required for updating hall-of-fame. For Batch Deployment this is however a critical service to schedule batch tests submitted via the API.


### PR DESCRIPTION
Removed obsoleter container internetnl-prod-resolver-permissive-1 since I watch all containers supposed to be running and this one no longer exists as far as I can see.