### PR TITLE
Ignore `documentation/**` for push and PR docker rebuilds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,12 +2,16 @@ name: Internet.nl Docker
 
 on:
   pull_request:
+    paths-ignore:
+      - 'documentation/**'
   release:
     types: [published]
   push:
     branches:
       - main
       - release/*
+    paths-ignore:
+      - 'documentation/**'
 
 env:
   DOCKER_REGISTRY: ghcr.io/${{ github.repository_owner }}


### PR DESCRIPTION
`documentation/**` is not included in the docker build, so no need to re-build/test on changes here. It would be useful to add a seperate spellchecker, markdown linter, etc. that does not exclude this path.