### PR TITLE
Use Rosetta for Apple sillicon for improved performance

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,9 @@ ARG PYTHON_VERSION=3.9
 # hashes/log output prefix build command with: `DOCKER_BUILDKIT=0`
 
 # generic stage used by all build stages
-FROM debian:bullseye-20241111-slim AS build-deps
+# explicitly amd64, as currently used (old) nassl version is not aarch64 compatible
+# platform can probably be removed after #1218
+FROM --platform=linux/amd64 debian:bullseye-20241111-slim AS build-deps
 ARG PYTHON_VERSION
 
 RUN apt update && \
@@ -78,7 +80,7 @@ COPY requirements-dev.txt /src/
 RUN pip3 install -r requirements-dev.txt
 
 # build unbound target
-FROM debian:bullseye-20241111-slim AS unbound
+FROM --platform=linux/amd64 debian:bullseye-20241111-slim AS unbound
 
 COPY --from=build-unbound /opt/unbound /opt/unbound
 
@@ -126,7 +128,7 @@ USER unbound
 ENTRYPOINT ["/entrypoint.sh"]
 
 # build main application image target
-FROM debian:bullseye-20241111-slim AS build-app
+FROM --platform=linux/amd64 debian:bullseye-20241111-slim AS build-app
 ARG PYTHON_VERSION
 
 RUN apt update && \

--- a/docker/compose.integration-tests.yaml
+++ b/docker/compose.integration-tests.yaml
@@ -26,6 +26,7 @@ services:
 
   # test runner for integration tests in isolated environment
   test-runner:
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_TEST_RUNNER:-${DOCKER_REGISTRY:-ghcr.io/internetstandards}/test-runner:$RELEASE}
     # don't run anything, just make this container available to run tests in on demand
     command: python3 -m pytest -v integration_tests/integration/
@@ -121,6 +122,7 @@ services:
       retries: 30
 
   mail-test-target:
+    platform: linux/amd64
     image: mailhog/mailhog:v1.0.1
 
     networks:
@@ -138,6 +140,7 @@ services:
 
   # internal resolver for the browser running the integration tests, makes sure test target hostname are resolved
   mock-resolver:
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_UNBOUND:-${DOCKER_REGISTRY:-ghcr.io/internetstandards}/unbound:$RELEASE}
 
     entrypoint: /opt/unbound/sbin/unbound

--- a/docker/compose.test-runner-develop.yaml
+++ b/docker/compose.test-runner-develop.yaml
@@ -1,6 +1,7 @@
 services:
   # test runner intended to run live tests against targets on public internet
   test-runner-development-environment:
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_TEST_RUNNER:-${DOCKER_REGISTRY:-ghcr.io/internetstandards}/test-runner:$RELEASE}
     environment:
       - APP_URLS

--- a/docker/compose.test-runner-live.yaml
+++ b/docker/compose.test-runner-live.yaml
@@ -1,6 +1,7 @@
 services:
   # test runner intended to run live tests against targets on public internet
   test-runner-live:
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_TEST_RUNNER:-${DOCKER_REGISTRY:-ghcr.io/internetstandards}/test-runner:$RELEASE}
     # don't run anything, just make this container available to run tests in on demand
     command: python3 -m pytest -v integration-tests/live/

--- a/docker/compose.test.yaml
+++ b/docker/compose.test.yaml
@@ -1,6 +1,7 @@
 services:
   # environment for checks, linting and unit tests
   test:
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_LINTTEST:-${DOCKER_REGISTRY:-ghcr.io/internetstandards}/linttest:$RELEASE}
 
     networks:

--- a/docker/compose.tools.yaml
+++ b/docker/compose.tools.yaml
@@ -1,5 +1,6 @@
 services:
   tools:
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_LINTTEST:-${DOCKER_REGISTRY:-ghcr.io/internetstandards}/linttest:${RELEASE:-latest}}
 
     volumes:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -6,6 +6,7 @@
 services:
   # nginx proxy container, also runs certbot
   webserver:
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_WEBSERVER:-${DOCKER_REGISTRY:-ghcr.io/internetstandards}/webserver:${RELEASE}}
     restart: unless-stopped
     logging:
@@ -69,6 +70,7 @@ services:
 
   # django container
   app:
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_APP:-${DOCKER_REGISTRY:-ghcr.io/internetstandards}/internet.nl:${RELEASE}}
     restart: unless-stopped
     logging:
@@ -172,6 +174,7 @@ services:
 
   # django DB migrations, runs to completion and exits with 0
   db-migrate:
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_APP:-${DOCKER_REGISTRY:-ghcr.io/internetstandards}/internet.nl:${RELEASE}}
     networks:
       - internal
@@ -206,6 +209,7 @@ services:
       - WORKER_CONCURRENCY
 
   worker: &worker
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_APP:-${DOCKER_REGISTRY:-ghcr.io/internetstandards}/internet.nl:${RELEASE}}
     deploy:
       replicas: $WORKER_REPLICAS
@@ -341,6 +345,7 @@ services:
 
   # celery task queue
   beat:
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_APP:-${DOCKER_REGISTRY:-ghcr.io/internetstandards}/internet.nl:${RELEASE}}
     restart: unless-stopped
     logging:
@@ -536,6 +541,7 @@ services:
 
   # unbound DNS server used for connection test
   unbound:
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_UNBOUND:-${DOCKER_REGISTRY:-ghcr.io/internetstandards}/unbound:${RELEASE}}
     depends_on:
       redis:
@@ -579,6 +585,7 @@ services:
 
   # unbound resolver used for ldns-dane that require DNSSEC validation
   resolver-validating:
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_UNBOUND:-${DOCKER_REGISTRY:-ghcr.io/internetstandards}/unbound:${RELEASE}}
 
     entrypoint: /entrypoint-resolver.sh
@@ -611,6 +618,7 @@ services:
 
   # cron with periodic tasks
   cron:
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_UTIL:-${DOCKER_REGISTRY:-ghcr.io/internetstandards}/util:${RELEASE}}
     command: crond -f -d7
     environment:
@@ -665,6 +673,7 @@ services:
 
   # cron daemon with access to Docker socket but no networking
   cron-docker:
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_UTIL:-${DOCKER_REGISTRY:-ghcr.io/internetstandards}/util:${RELEASE}}
     command: crond -f -d7 -c /etc/crontabs-docker
     environment:
@@ -688,6 +697,7 @@ services:
       - /opt/Internet.nl:/opt/Internet.nl
 
   grafana:
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_GRAFANA:-${DOCKER_REGISTRY:-ghcr.io/internetstandards}/grafana:${RELEASE}}
 
     environment:
@@ -851,6 +861,7 @@ services:
       - monitoring
 
   celery-exporter:
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_CELERY_EXPORTER}
     command:
       - --broker-url=amqp://guest:guest@$IPV4_IP_RABBITMQ_INTERNAL:5672/
@@ -909,6 +920,7 @@ services:
 
   docker_stats_exporter:
     # https://github.com/jan4843/docker_stats_exporter
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_DOCKER_STATSD_EXPORTER}
     environment:
       LABEL_state: '{{.Container.State}}'
@@ -930,6 +942,7 @@ services:
       - monitoring
 
   nginx_logs_exporter:
+    platform: linux/amd64
     image: ${DOCKER_IMAGE_NGINX_LOGS_EXPORTER}
     command:
       - -config-file=/config.hcl

--- a/documentation/Docker-development-environment.md
+++ b/documentation/Docker-development-environment.md
@@ -283,7 +283,7 @@ Stop and delete potential previous Colima instance:
 
 Create new Colima instance with `shared` network (adjust `memory` to as much GB as you can spare):
 
-    colima start --memory=4 --network-address --network-driver=slirp --arch=x86_64 --edit
+    colima start --memory=4 --network-address --arch=aarch64 --vz-rosetta --edit
 
 This will also open an editor in which the following changes need to be applied:
 


### PR DESCRIPTION
Using an aarch64 colima VM with Rosetta enabled, and amd64 images for our own builds, dramatically speeds up performance on Apple silicon. 