### PR TITLE
Fix #1730 - CSS print permalink date and link

### DIFF
--- a/frontend/css/print.css
+++ b/frontend/css/print.css
@@ -21,9 +21,14 @@ aside,
 .footlink,
 .panel-button-container,
 .panel-title a .icon,
-.timestamp,
+.timestamp > :not(a.permalink),
 #site-description {
   display:none !important;
+}
+
+/* print permalink */
+a.permalink::after {
+  content: ": " attr(href);
 }
 
 /* print design */


### PR DESCRIPTION
- Fix #1730

Note that the used [`:not()` is extremely well supported](https://developer.mozilla.org/en-US/docs/Web/CSS/:not#browser_compatibility).