### PR TITLE
Add archive support, fix #1634

### DIFF
--- a/interface/views/domain.py
+++ b/interface/views/domain.py
@@ -6,7 +6,7 @@ import re
 from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import DisallowedRedirect
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect, HttpResponseNotFound
 from django.shortcuts import render
 from django.utils.translation import gettext as _
 
@@ -34,6 +34,7 @@ from interface.views.shared import (
     redirect_invalid_domain,
     update_report_with_registrar_and_score,
     SafeHttpResponseRedirect,
+    latest_report,
 )
 
 # Entrance after form submission.
@@ -186,6 +187,12 @@ def resultscurrent(request, dname):
         )
 
     return HttpResponseRedirect(f"/site/{addr}/{report.id}/")
+
+
+def resultsstored_historic(request, domain_name, date):
+    if report := latest_report(DomainTestReport, domain_name, date):
+        return resultsrender(report.domain, report, request)
+    return HttpResponseNotFound()
 
 
 # URL: /(site|domain)/<dname>/<reportid>/

--- a/interface/views/mail.py
+++ b/interface/views/mail.py
@@ -5,7 +5,7 @@ import re
 
 from django.conf import settings
 from django.core.cache import cache
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect, HttpResponseNotFound
 from django.shortcuts import render
 from django.utils.translation import gettext as _
 
@@ -32,6 +32,7 @@ from interface.views.shared import (
     process,
     redirect_invalid_domain,
     update_report_with_registrar_and_score,
+    latest_report,
 )
 from internetnl import log
 
@@ -180,6 +181,12 @@ def resultscurrent(request, mailaddr):
         )
 
     return HttpResponseRedirect(f"/mail/{addr}/{report.id}/")
+
+
+def resultsstored_historic(request, domain_name, date):
+    if report := latest_report(MailTestReport, domain_name, date):
+        return resultsrender(report.domain, report, request)
+    return HttpResponseNotFound()
 
 
 # URL: /mail/<dname>/<reportid>/

--- a/interface/views/shared.py
+++ b/interface/views/shared.py
@@ -482,3 +482,22 @@ class SafeHttpResponseRedirect(HttpResponseRedirect):
 
         if not settings.DEBUG and not url_has_allowed_host_and_scheme(redirect_to, allowed_hosts=allowed_hosts):
             raise DisallowedRedirect("Unsafe redirect to URL: %s" % redirect_to)
+
+
+def latest_report(model, domain_name: str, date: datetime):
+    # probably the default ordering in the database is on -id or -timestamp. Both will work.
+    # domain does not have an index, timestamp neither. This might be a problem, but it also might just work fine.
+
+    # for caching purposes don't allow users to request domains newer than today:
+    # assume users don't enter timezones, they can, and that will crash here due to non-zone-awareness :)
+    if date > datetime.now():
+        log.debug("Will not hand out reports in the future.")
+        date = datetime.now()
+
+    # if no time is given, the first moment of the day is assumed, at that time the report did not exist yet.
+    # so if people try with just a date, they will not get what they expect: the latest report for that day.
+    if date.hour == 0 and date.minute == 0 and date.second == 0:
+        log.debug("Aiding the user to set the date of the date to the latest report of the day.")
+        date = date.replace(hour=23, minute=59, second=59)  # try to get the latest report of this day.
+
+    return model.objects.all().filter(domain=domain_name, timestamp__lte=date).order_by("-timestamp").first()


### PR DESCRIPTION
Support archived links from the dashboard and other sources.

For example, loading the report from example.nl from a few weeks ago:

http://localhost:8080/archive/mail/example.nl/2025-05-04/

This change removes a large chunk of data (millions of rows) from the dashboard as no unique ID is needed anymore to visit the correct report. This saves the unique ID every time a report is made. Additionally it is a very convenient feature for some users that use internet.nl for compliance, as they can now retrieve the last report from December with ease (if this feature is promoted).

This solves issue #1634

The sooner this can be placed into batch, the better, as we then can start cleaning up the database and keep things fast and efficient :)
