### PR TITLE
Fix CAA syntax/insufficient detection and UTF-8

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,8 @@ _Compared to the latest 1.10 release._
 ## 1.10.2
 
 - Added missing [CAA fields to API](https://github.com/internetstandards/Internet.nl/pull/1801).
+- Fixed [incomplete detection of insufficient or invalid CAA](https://github.com/internetstandards/Internet.nl/pull/1811)
+  along with some improvements in UTF-8 handling.
 
 The API version is updated to 2.6.0 due to the new CAA fields.
 

--- a/checks/tasks/tls.py
+++ b/checks/tasks/tls.py
@@ -657,7 +657,7 @@ def save_results(model, results, addr, domain, category):
                 model.cert_hostmatch_bad = result.get("hostmatch_bad")
                 model.caa_enabled = result.get("caa_result").caa_found
                 model.caa_records = result.get("caa_result").caa_records_str
-                model.caa_error = [ttti.to_dict() for ttti in result.get("caa_result").errors]
+                model.caa_errors = [ttti.to_dict() for ttti in result.get("caa_result").errors]
                 model.caa_recommendations = [ttti.to_dict() for ttti in result.get("caa_result").recommendations]
                 model.caa_score = result.get("caa_result").score
                 model.caa_found_on_domain = result.get("caa_result").canonical_name
@@ -731,7 +731,7 @@ def save_results(model, results, addr, domain, category):
                     model.cert_hostmatch_bad = result.get("hostmatch_bad")
                     model.caa_enabled = result.get("caa_result").caa_found
                     model.caa_records = result.get("caa_result").caa_records_str
-                    model.caa_error = [ttti.to_dict() for ttti in result.get("caa_result").errors]
+                    model.caa_errors = [ttti.to_dict() for ttti in result.get("caa_result").errors]
                     model.caa_recommendations = [ttti.to_dict() for ttti in result.get("caa_result").recommendations]
                     model.caa_score = result.get("caa_result").score
                     model.caa_found_on_domain = result.get("caa_result").canonical_name
@@ -908,7 +908,7 @@ def build_report(dttls, category):
                 if not dttls.caa_enabled:
                     category.subtests["web_caa"].result_bad(caa_tech_table)
                 elif dttls.caa_errors:
-                    if all([ttti.msgid != CAA_MSGID_INSUFFICIENT_POLICY for ttti in dttls.caa_errors]):
+                    if all([error["msgid"] != CAA_MSGID_INSUFFICIENT_POLICY for error in dttls.caa_errors]):
                         category.subtests["web_caa"].result_syntax_error(caa_tech_table)
                     else:
                         category.subtests["web_caa"].result_insufficient(caa_tech_table)
@@ -1087,7 +1087,7 @@ def build_report(dttls, category):
             if not dttls.caa_enabled:
                 category.subtests["mail_caa"].result_bad(caa_tech_table)
             elif dttls.caa_errors:
-                if all([ttti.msgid != CAA_MSGID_INSUFFICIENT_POLICY for ttti in dttls.caa_errors]):
+                if all([error["msgid"] != CAA_MSGID_INSUFFICIENT_POLICY for error in dttls.caa_errors]):
                     category.subtests["mail_caa"].result_syntax_error(caa_tech_table)
                 else:
                     category.subtests["mail_caa"].result_insufficient(caa_tech_table)

--- a/integration_tests/batch/results.py
+++ b/integration_tests/batch/results.py
@@ -93,7 +93,14 @@ EXPECTED_DOMAIN_TECHNICAL_RESULTS = {
                 "cert_signature_bad": {},
                 "cert_hostmatch_bad": [],
                 "caa_enabled": False,
-                "caa_errors": [],
+                "caa_errors": [
+                    {
+                        "context": {
+                            "property_tag": "issue",
+                        },
+                        "msgid": "missing-required-property-issue",
+                    },
+                ],
                 "caa_recommendations": [],
                 "caa_records": [],
                 "caa_found_on_domain": None,
@@ -150,7 +157,14 @@ EXPECTED_DOMAIN_TECHNICAL_RESULTS = {
                 "cert_signature_bad": {},
                 "cert_hostmatch_bad": [],
                 "caa_enabled": False,
-                "caa_errors": [],
+                "caa_errors": [
+                    {
+                        "context": {
+                            "property_tag": "issue",
+                        },
+                        "msgid": "missing-required-property-issue",
+                    },
+                ],
                 "caa_recommendations": [],
                 "caa_records": [],
                 "caa_found_on_domain": None,

--- a/translations/en/main.po
+++ b/translations/en/main.po
@@ -1935,6 +1935,9 @@ msgstr ""
 "{invalid_character_position} in '{property_name}' value \"{property_value}\""
 " "
 
+msgid "detail tech data caa invalid-property-encoding"
+msgstr "Error: Invalid encoding in '{property_name}'"
+
 msgid "detail tech data caa invalid-reserved-property"
 msgstr "Error: Invalid reserved property \"{property_tag}\""
 

--- a/translations/nl/main.po
+++ b/translations/nl/main.po
@@ -1944,6 +1944,9 @@ msgstr ""
 "{invalid_character_position} in '{property_name}'-waarde "
 "\"{property_value}\""
 
+msgid "detail tech data caa invalid-property-encoding"
+msgstr "Fout: Ongeldige encoding in '{property_name}'"
+
 msgid "detail tech data caa invalid-reserved-property"
 msgstr "Fout: Ongeldige gereserveerde property \"{property_tag}\""
 


### PR DESCRIPTION
- Due to a caa_error/caa_errors typo, insufficient or syntax error
  cases were never detected for CAA.
- UTF-8 handling was modified to avoid masking syntax errors.
- Cleaned up some unused flags in CAAEvaluation. Those were probably
  meant to prevent the first point, but our layers of dicts and models
  mean the code flagging the result does not have access to the eval.
