### PR TITLE
Fix #1808 - Handle NoAnswer correctly for DMARC

### DIFF
--- a/checks/tasks/mail.py
+++ b/checks/tasks/mail.py
@@ -477,7 +477,7 @@ def do_dmarc(url, *args, **kwargs):
         log.debug("Soft time limit exceeded: %s", specific_exception)
         result = dict(
             available=False,
-            score=scoring.MAIL_AUTH_DMARC_FAIL,
+            score=scoring.MAIL_AUTH_DMARC_ERROR,
             record=[],
             policy_status=None,
             policy_score=scoring.MAIL_AUTH_DMARC_POLICY_FAIL,

--- a/checks/tasks/mail.py
+++ b/checks/tasks/mail.py
@@ -430,6 +430,9 @@ def _dmarc_dns_lookup(url):
     except NXDOMAIN:
         score = scoring.MAIL_AUTH_DMARC_FAIL
         continue_looking = True
+    except NoAnswer:  # https://github.com/internetstandards/Internet.nl/issues/1808
+        score = scoring.MAIL_AUTH_DMARC_FAIL
+        continue_looking = True
     except DNSException:
         score = scoring.MAIL_AUTH_DMARC_ERROR
 


### PR DESCRIPTION
- **Fix #1808 - Handle NoAnswer correctly for DMARC**
- **Ref #1808 - set DMARC error instead of fail for certain exceptions**
