### PR TITLE
[1.10.x] Fix OpenAPI syntax issues, add 1.10.6 to changelog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.10.6
+
+- Fixed a syntax error in the OpenAPI specification.
+
 ## 1.10.5
 
 - Fixed an issue in 1.10.x where [DNSSEC test could return false negatives](https://github.com/internetstandards/Internet.nl/issues/1869)

--- a/interface/batch/openapi.yaml
+++ b/interface/batch/openapi.yaml
@@ -736,7 +736,7 @@ components:
             type: string
 
         caa_enabled:
-          type: bool
+          type: boolean
           description: Whether CAA records were found.
           items:
             type: string
@@ -754,7 +754,7 @@ components:
           type: array
           description: The found CAA records
           items:
-            $ref: string
+            type: string
         caa_found_on_domain:
           type: string
           description: Domain name under which the CAA record was found.


### PR DESCRIPTION
(cherry picked from commit 8df2d12920709a484f2a43faf39ac0fcdc81a9e3)