### PR TITLE
Fix #1937 - Remove docker network IPv4/6 in develop

### DIFF
--- a/docker/compose.development.yaml
+++ b/docker/compose.development.yaml
@@ -70,3 +70,11 @@ services:
       - ../checks:/app/checks
       - ../interface:/app/interface
       - ../internetnl:/app/internetnl
+
+networks:
+  public-internet:
+    driver_opts: !override # to remove com.docker.network.host_ipv[46] in dev
+      # required to enable IPv6 on Colima Docker runtime
+      com.docker.network.enable_ipv6: "true"
+      # network for internal communication between services
+      com.docker.network.bridge.enable_icc: "true"


### PR DESCRIPTION
- Fixes #1937
- Also see https://github.com/internetstandards/Internet.nl/pull/1930#issuecomment-3916032303

@aequitas: this fixes it for me (after doing a `make down-remove-volumes env=develop` first). Another way would be to move the IPv4/6 fix from the compose.yaml to a (new) compose.production.yaml, which would be a bit more DRY than using `!overwrite` and repeating the two items in compose.development.yaml.