### PR TITLE
Fix #1936 - Add new ACME validation methods `onion-csr-01` and `bp-nodeid-00`

### DIFF
--- a/checks/caa/parser.py
+++ b/checks/caa/parser.py
@@ -38,11 +38,11 @@ def node_get_named_child_value(node: Node, name: str) -> Optional[str]:
 ACME_VALIDATION_METHODS = {
     "http-01",
     "dns-01",
-    "http-01",
-    "tls-alpn-01",
     "tls-alpn-01",
     "email-reply-00",
     "tkauth-01",
+    "onion-csr-01",
+    "bp-nodeid-00",
 }
 
 # RFC 8657 4


### PR DESCRIPTION
- Fix #1936 

Automated with a bash one-liner:
```bash
$ sed -i -rz 's/(\nACME_VALIDATION_METHODS = \{\n)[^}]+(\})/\1'"$(curl -sSf https://www.iana.org/assignments/acme/acme-validation-methods.csv|awk -F, 'NR>1&&$3=="Y"{if(!c[$1])printf "    \"%s\",\\n",$1;c[$1]++}')"'\2/' checks/caa/parser.py
```

I noticed the duplicate `http-01` and `tls-alpn-01` got removed, that was an error and serves no mapping purpose right @mxsasha?