### PR TITLE
Use bundled compose instead of system one to reduce issues with diffe…

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,11 +19,12 @@ env:
   # should be used to transfer images between jobs. Forked and dependabot builds don't
   # have permission to push to registry.
   use_registry: ${{ ! (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || startsWith(github.head_ref, 'dependabot/'))) }}
+  COMPOSE_VERSION: 2.40.3
 
 jobs:
   # builds all docker images in parallel
   build-docker:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
@@ -227,7 +228,7 @@ jobs:
           retention-days: 1
 
   docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [build-docker]
     steps:
       - name: Branch deployment docs
@@ -272,7 +273,7 @@ jobs:
           sudo apt-get update
 
           # upgrade Docker
-          sudo apt install --upgrade docker-ce docker-compose-plugin=2.33.0\*
+          sudo apt install --upgrade docker-ce docker-compose-plugin=$COMPOSE_VERSION\*
 
       - name: Debug info
         run: |
@@ -374,7 +375,7 @@ jobs:
   lintcheck:
     name: lint/check
     needs: [build-docker]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     env:
       # used in `compose.yaml` files to determine version of images to pull
@@ -452,7 +453,7 @@ jobs:
           sudo apt-get update
 
           # upgrade Docker
-          sudo apt install --upgrade docker-ce docker-compose-plugin=2.33.0\*
+          sudo apt install --upgrade docker-ce docker-compose-plugin=$COMPOSE_VERSION\*
 
       - name: Debug info
         run: |
@@ -539,7 +540,7 @@ jobs:
           sudo apt-get update
 
           # upgrade Docker
-          sudo apt install --upgrade docker-ce docker-compose-plugin=2.33.0\*
+          sudo apt install --upgrade docker-ce docker-compose-plugin=$COMPOSE_VERSION\*
 
       - name: Debug info
         run: |
@@ -657,7 +658,7 @@ jobs:
           sudo apt-get update
 
           # upgrade Docker
-          sudo apt install --upgrade docker-ce docker-compose-plugin=2.33.0\*
+          sudo apt install --upgrade docker-ce docker-compose-plugin=$COMPOSE_VERSION\*
 
       - name: Debug info
         run: |

--- a/docker/compose-dist.sh
+++ b/docker/compose-dist.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+# wrapper to run the right compose command with the right environment variables from the util container
+
+set -e
+
+# determine install base for multi environment deployments (parent of directory containing this file)
+INTERNETNL_INSTALL_BASE=$(dirname "$(dirname "$(readlink -f "$0")")")
+
+exec docker run -ti --rm --pull=never \
+  --volume /var/run/docker.sock:/var/run/docker.sock \
+  --volume "$INTERNETNL_INSTALL_BASE:/opt/Internet.nl" \
+  --workdir /opt/Internet.nl \
+  --network none \
+  "ghcr.io/internetstandards/util:$RELEASE" \
+  docker compose --env-file=docker/defaults.env --env-file=docker/host.env --env-file=docker/local.env "$@"

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -8,6 +8,9 @@ echo "Deploying release: $RELEASE"
 
 # copy release specific support files
 cp -v /dist/docker/* docker
+# put $RELEASE into the compose.sh file
+envsubst '$RELEASE' < docker/compose-dist.sh > docker/compose.sh
+chmod a+x docker/compose.sh
 
 # set release version in local.env config
 echo "RELEASE='$RELEASE' # deploy $(date)" >> docker/local.env

--- a/docker/util.Dockerfile
+++ b/docker/util.Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.20.3
+FROM alpine:3.22
 
-RUN apk add --no-cache curl postgresql15 python3 py3-prometheus-client py3-requests jq docker-cli docker-cli-compose pigz jq
+RUN apk add --no-cache curl postgresql15 python3 py3-prometheus-client py3-requests jq docker-cli docker-cli-compose pigz jq envsubst
 
 # install cron tasks
 COPY docker/cron/periodic /etc/periodic/
@@ -25,6 +25,7 @@ COPY docker/host-dist.env /dist/docker/
 COPY docker/host-multi-dist.env /dist/docker/
 COPY docker/compose.yaml /dist/docker/
 COPY docker/user_manage.sh /dist/docker/
+COPY docker/compose-dist.sh /dist/docker/
 RUN chmod a-w /dist/docker/*
 
 # add release as label for auto_update feature

--- a/documentation/Docker-DNS.md
+++ b/documentation/Docker-DNS.md
@@ -114,11 +114,11 @@ Letsencrypt account ID and private key are stored in a Docker volume for persist
 
 When deploying a new instance, first complete the full setup. After that perform the following steps to restore the account:
 
-    docker compose --project-name=internetnl-prod stop webserver
+    /opt/Internet.nl/docker/compose.sh stop webserver
     rm -rf /var/lib/docker/volumes/internetnl-prod_certbot-config/_data/*
     cp -r <location of backed up _data directory> /var/lib/docker/volumes/internetnl-prod_certbot-config/_data/
-    docker compose --project-name=internetnl-prod start webserver
+    /opt/Internet.nl/docker/compose.sh start webserver
 
 The certbot instance in the webserver container should start requesting a certificate for the domain after at most 1 minute. You can check the progress using:
 
-    docker compose --project-name=internetnl-prod exec webserver cat /var/log/letsencrypt/letsencrypt.log
+    /opt/Internet.nl/docker/compose.sh exec webserver cat /var/log/letsencrypt/letsencrypt.log

--- a/documentation/Docker-getting-started.md
+++ b/documentation/Docker-getting-started.md
@@ -4,17 +4,13 @@ This documented is intended as a quick simple guide to setup a development envir
 
 ## Prerequisites
 
-An OCI compatible container runtime with [Compose V2](https://docs.docker.com/compose/migrate/) is required to run the project. For example one of the following:
+An OCI compatible container runtime (Docker) with a recent [Compose](https://github.com/docker/compose) is required to run the project. For example one of the following:
 
 - [Docker](https://docs.docker.com/get-docker/) for Linux, (supported)
 - [Colima](https://github.com/abiosoft/colima) for Mac (recommended)
-- [OrbStack](https://orbstack.dev/download) for Mac (non open source, free, tested version 1.10.2)
+- [OrbStack](https://orbstack.dev/download) for Mac (non open source, free, tested version 2.0.5)
 - [Docker](https://docs.docker.com/get-docker/) for Mac (supported)
 - [Docker](https://docs.docker.com/get-docker/) for Windows (untested)
-
-**notice**: some versions of Docker Engine might experience issues with internal DNS resolving and will cause tests to fail. Versions from and including `25.0.5` to and including `26.1.2` should be avoided.
-
-**notice**: Docker Compose Plugin versions below and up to `2.27.2` should be avoided due to missing features.
 
 **notice**: your Docker runtime should be configured with enough memory and CPU, otherwise the environment will be unstable. Minimum is at least 4GB memory and 2 CPU cores, more is better for quicker rebuild/restart of images/containers.
 

--- a/documentation/Docker-multi-deployment.md
+++ b/documentation/Docker-multi-deployment.md
@@ -15,13 +15,13 @@ To save on resources the routinator service can be shared between the instances.
 - Additional public IPv4 and IPv6 address pairs bound to the server, one pair for each extra instance
 - Unique public (sub)domain names for each IP pair
 - Additional server resources (CPU, Memory (~1GB), disk space) depending on the number of instances
-- Existing deployment of the Internet.nl application stack (see: [Application setup](#application-setup))
+- Existing deployment of the Internet.nl application stack (see: [Application setup](Docker-deployment.md#application-setup))
 
 ## Renaming initial instance
 
 Bring down the initial instance and rename it to `dev1`, renaming all existing volumes:
 
-    docker compose --project-name internetnl-prod down
+    /opt/Internet.nl/docker/compose.sh down
     mv /opt/Internet.nl /opt/Internet.nl-dev1
     cd /var/lib/docker/volumes
     rename 's/prod/dev1/' internetnl-prod_*
@@ -29,7 +29,7 @@ Bring down the initial instance and rename it to `dev1`, renaming all existing v
     echo INTERNETNL_INSTALL_BASE=/opt/Internet.nl-dev1 >> docker/host.env
     sed -i 's/dev-docker/dev1/' docker/host.env
     sed -i 's/internetnl-prod/internetnl-dev1/' docker/host.env
-    docker compose --env-file=docker/defaults.env --env-file=docker/host.env --env-file=docker/local.env up --remove-orphans --wait --no-build
+    /opt/Internet.nl-dev1/docker/compose.sh up --remove-orphans --wait --no-build
 
 Add the following lines to `docker/host.env` and change the IP's to the public IP's for the dev1 instances:
 
@@ -101,7 +101,7 @@ If you have manually defined user/password added using the `docker/user_manage.s
 
 Getting DS records for all instances:
 
-    for i in {1..5}; do docker compose --project-name internetnl-dev$i restart unbound 2>&1;  docker compose --project-name internetnl-dev$i logs unbound 2>&1 | grep -A2 "Please add the following DS records for domain";done | grep "IN	DS"
+    for i in {1..5}; do /opt/Internet.nl-dev$i/docker/compose.sh restart unbound;  /opt/Internet.nl-dev$i/docker/compose.sh logs unbound | grep -A2 "Please add the following DS records for domain";done | grep "IN	DS"
 
 Copy password file from `dev1` to all other instances
 


### PR DESCRIPTION
…rent versions of compose

- simplify deployment instructions by removing version pins as those where for Docker versions more than a year old