### PR TITLE
Small remaining TLS fixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -53,6 +53,7 @@ Additionally, the API structure changes are:
 - The cipher order status no longer returns `not_prescribed` or `not_seclevel` for new tests.
   The insufficient statuses is now `bad` for preferring phase out over good and/or sufficient,
   regardless of the reason (server not enforcing any preference or server enforcing wrong preference).
+- `cert_signature_phase_out` was added to the TLS details.
 - `extended_master_secret_status` was added to the TLS details.
 - `client_reneg` in the TLS details was changed from a boolean to a new enum.
 

--- a/checks/categories.py
+++ b/checks/categories.py
@@ -1281,6 +1281,11 @@ class WebTlsCertSignature(Subtest):
         self.verdict = "detail web tls cert-signature verdict good"
         self.tech_data = ""
 
+    def result_phase_out(self, tech_data):
+        self._status(STATUS_NOTICE)
+        self.verdict = "detail web tls cert-signature verdict phase-out"
+        self.tech_data = tech_data
+
     def result_bad(self, tech_data):
         self._status(STATUS_FAIL)
         self.verdict = "detail web tls cert-signature verdict bad"
@@ -1959,6 +1964,12 @@ class MailTlsCertSignature(Subtest):
         self._status(STATUS_SUCCESS)
         self.verdict = "detail mail tls cert-signature verdict good"
         self.tech_data = ""
+
+    def result_phase_out(self, tech_data):
+        self.was_tested()
+        self._status(STATUS_NOTICE)
+        self.verdict = "detail mail tls cert-signature verdict phase-out"
+        self.tech_data = tech_data
 
     def result_bad(self, tech_data):
         self.was_tested()

--- a/checks/migrations/0022_domaintesttls_cert_signature_phase_out.py
+++ b/checks/migrations/0022_domaintesttls_cert_signature_phase_out.py
@@ -1,0 +1,16 @@
+import checks.models
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("checks", "0021_domaintesttls_kex_hash_func_techtable"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="domaintesttls",
+            name="cert_signature_phase_out",
+            field=checks.models.ListField(null=True),
+        ),
+    ]

--- a/checks/models.py
+++ b/checks/models.py
@@ -569,6 +569,7 @@ class DomainTestTls(BaseTestModel):
     cert_pubkey_score = models.IntegerField(null=True)
 
     cert_signature_bad = ListField(null=True)
+    cert_signature_phase_out = ListField(null=True)
     cert_signature_score = models.IntegerField(null=True)
 
     cert_hostmatch_bad = ListField(null=True)
@@ -641,6 +642,7 @@ class DomainTestTls(BaseTestModel):
             "cert_pubkey_phase_out",
             "cert_pubkey_score",
             "cert_signature_bad",
+            "cert_signature_phase_out",
             "cert_signature_score",
             "cert_hostmatch_bad",
             "cert_hostmatch_score",
@@ -682,6 +684,7 @@ class DomainTestTls(BaseTestModel):
             "cert_pubkey_bad": self.cert_pubkey_bad,
             "cert_pubkey_phase_out": self.cert_pubkey_phase_out,
             "cert_signature_bad": self.cert_signature_bad,
+            "cert_signature_phase_out": self.cert_signature_phase_out,
             "cert_hostmatch_bad": self.cert_hostmatch_bad,
             "caa_enabled": self.caa_enabled,
             "caa_errors": self.caa_errors,
@@ -714,6 +717,7 @@ class DomainTestTls(BaseTestModel):
             "cert_pubkey_bad": self.cert_pubkey_bad,
             "cert_pubkey_phase_out": self.cert_pubkey_phase_out,
             "cert_signature_bad": self.cert_signature_bad,
+            "cert_signature_phase_out": self.cert_signature_phase_out,
             "cert_hostmatch_bad": self.cert_hostmatch_bad,
         }
 

--- a/checks/tasks/tls/scans.py
+++ b/checks/tasks/tls/scans.py
@@ -77,6 +77,7 @@ from checks.tasks.tls.evaluation import (
 )
 from checks.tasks.tls.tls_constants import (
     CERT_SIGALG_SUFFICIENT,
+    CERT_SIGALG_PHASE_OUT,
     CERT_CURVES_GOOD,
     CERT_EC_CURVES_GOOD,
     CERT_EC_CURVES_PHASE_OUT,
@@ -387,13 +388,17 @@ def cert_checks(hostname: str, mode: ChecksMode, af_ip_pair=None, *args, **kwarg
 
     # NCSC 3.3.2 / 3.3.5
     sigalg_bad = {}
+    sigalg_phase_out = {}
     sigalg_score = scoring.WEB_TLS_SIGNATURE_GOOD
     for cert in cert_deployment.received_certificate_chain:
         if not is_root_cert(cert):
             sigalg = cert.signature_algorithm_oid
             if sigalg not in CERT_SIGALG_SUFFICIENT:
-                sigalg_bad[get_common_name(cert)] = sigalg._name
-                sigalg_score = scoring.WEB_TLS_SIGNATURE_BAD
+                if sigalg in CERT_SIGALG_PHASE_OUT:
+                    sigalg_phase_out[get_common_name(cert)] = sigalg._name
+                else:
+                    sigalg_bad[get_common_name(cert)] = sigalg._name
+                    sigalg_score = scoring.WEB_TLS_SIGNATURE_BAD
 
     chain_str = []
     for cert in cert_deployment.received_certificate_chain:
@@ -423,6 +428,7 @@ def cert_checks(hostname: str, mode: ChecksMode, af_ip_pair=None, *args, **kwarg
         pubkey_phase_out=pubkey_phase_out,
         pubkey_score=pubkey_score,
         sigalg_bad=sigalg_bad,
+        sigalg_phase_out=sigalg_phase_out,
         sigalg_score=sigalg_score,
         hostmatch_bad=hostmatch_bad,
         hostmatch_score=hostmatch_score,

--- a/checks/tasks/tls/tasks_reports.py
+++ b/checks/tasks/tls/tasks_reports.py
@@ -287,6 +287,7 @@ def save_results(model, results, addr, domain, category):
                 model.cert_pubkey_phase_out = result.get("pubkey_phase_out")
                 model.cert_pubkey_score = result.get("pubkey_score")
                 model.cert_signature_bad = result.get("sigalg_bad")
+                model.cert_signature_phase_out = result.get("sigalg_phase_out")
                 model.cert_signature_score = result.get("sigalg_score")
                 model.cert_hostmatch_score = result.get("hostmatch_score")
                 model.cert_hostmatch_bad = result.get("hostmatch_bad")
@@ -364,6 +365,7 @@ def save_results(model, results, addr, domain, category):
                     model.cert_pubkey_phase_out = result.get("pubkey_phase_out")
                     model.cert_pubkey_score = result.get("pubkey_score")
                     model.cert_signature_bad = result.get("sigalg_bad")
+                    model.cert_signature_phase_out = result.get("sigalg_phase_out")
                     model.cert_signature_score = result.get("sigalg_score")
                     model.cert_hostmatch_score = result.get("hostmatch_score")
                     model.cert_hostmatch_bad = result.get("hostmatch_bad")
@@ -500,6 +502,8 @@ def build_report(dttls, category):
                     pass
                 elif len(dttls.cert_signature_bad) > 0:
                     category.subtests["cert_signature"].result_bad(dttls.cert_signature_bad)
+                elif len(dttls.cert_signature_phase_out) > 0:
+                    category.subtests["cert_signature"].result_phase_out(dttls.cert_signature_phase_out)
                 else:
                     category.subtests["cert_signature"].result_good()
 
@@ -661,6 +665,8 @@ def build_report(dttls, category):
                     pass
                 elif len(dttls.cert_signature_bad) > 0:
                     category.subtests["cert_signature"].result_bad(dttls.cert_signature_bad)
+                elif len(dttls.cert_signature_phase_out) > 0:
+                    category.subtests["cert_signature"].result_phase_out(dttls.cert_signature_phase_out)
                 else:
                     category.subtests["cert_signature"].result_good()
 

--- a/checks/tasks/tls/tls_constants.py
+++ b/checks/tasks/tls/tls_constants.py
@@ -15,6 +15,10 @@ CERT_SIGALG_SUFFICIENT = [
     SignatureAlgorithmOID.ED25519,
     SignatureAlgorithmOID.ED448,
 ]
+CERT_SIGALG_PHASE_OUT = [
+    SignatureAlgorithmOID.RSA_WITH_SHA224,
+    SignatureAlgorithmOID.ECDSA_WITH_SHA224,
+]
 
 # NCSC 3.3.2.1
 CERT_RSA_MIN_GOOD_KEY_SIZE = 3072

--- a/integration_tests/batch/results.py
+++ b/integration_tests/batch/results.py
@@ -92,6 +92,7 @@ EXPECTED_DOMAIN_TECHNICAL_RESULTS = {
                 "cert_pubkey_bad": [],
                 "cert_pubkey_phase_out": [],
                 "cert_signature_bad": {},
+                "cert_signature_phase_out": {},
                 "cert_hostmatch_bad": [],
                 "caa_enabled": False,
                 "caa_errors": [
@@ -157,6 +158,7 @@ EXPECTED_DOMAIN_TECHNICAL_RESULTS = {
                 "cert_pubkey_bad": [],
                 "cert_pubkey_phase_out": [],
                 "cert_signature_bad": {},
+                "cert_signature_phase_out": {},
                 "cert_hostmatch_bad": [],
                 "caa_enabled": False,
                 "caa_errors": [

--- a/interface/batch/openapi.yaml
+++ b/interface/batch/openapi.yaml
@@ -737,6 +737,14 @@ components:
             x-additionalPropertiesName: <certificate common name>
             type: string
             description: BAD hash description.
+        cert_signature_phase_out:
+          type: object
+          description: >
+            Collection of PHASE_OUT hashes used for certificate signing.
+          additionalProperties:
+            x-additionalPropertiesName: <certificate common name>
+            type: string
+            description: PHASE_OUT hash description.
         cert_hostmatch_bad:
           type: array
           description: >


### PR DESCRIPTION
- **Fix #1964 - OCSP not-in-cert -> status_not_tested**
- **Fixes to labels/status of EMS fields.**
- **Add cert_signature_phase_out detection for SHA224.**
