### PR TITLE
Fix #2046 - Fix false positive with 1.2/1.3 cipher mixing

### DIFF
--- a/checks/tasks/tls/evaluation.py
+++ b/checks/tasks/tls/evaluation.py
@@ -164,6 +164,7 @@ class TLSCipherEvaluation:
     ciphers_good: list[CipherSuite]
     ciphers_good_no_tls13: list[CipherSuite]
     ciphers_sufficient: list[CipherSuite]
+    ciphers_sufficient_no_tls13: list[CipherSuite]
     ciphers_phase_out: list[CipherSuite]
     ciphers_bad: list[CipherSuite]
 
@@ -191,6 +192,7 @@ class TLSCipherEvaluation:
             ciphers_good=ciphers_good,
             ciphers_good_no_tls13=[c for c in ciphers_good if c.name not in _TLS_1_3_CIPHER_SUITES],
             ciphers_sufficient=ciphers_sufficient,
+            ciphers_sufficient_no_tls13=[c for c in ciphers_sufficient if c.name not in _TLS_1_3_CIPHER_SUITES],
             ciphers_phase_out=ciphers_phase_out,
             ciphers_bad=ciphers_bad,
             ciphers_good_str=cls._format_str(ciphers_good),

--- a/checks/tasks/tls/scans.py
+++ b/checks/tasks/tls/scans.py
@@ -1033,7 +1033,7 @@ def test_cipher_order(
     order_tuples = [
         (
             cipher_evaluation.ciphers_phase_out,
-            cipher_evaluation.ciphers_sufficient + cipher_evaluation.ciphers_good_no_tls13,
+            cipher_evaluation.ciphers_sufficient_no_tls13 + cipher_evaluation.ciphers_good_no_tls13,
         ),
     ]
     for expected_less_preferred, expected_more_preferred_list in order_tuples:


### PR DESCRIPTION
We would test a 1.3 sufficient against a 1.2 phase out, openssl
would silently ignore the 1.3 cipher on the 1.2 conn,
therefore establish with the 1.2 cipher.

Accidentally, this was also fixed as a side effect in 799b07ac:
if we don't have 1.3 cipher detection, we can't trigger this bug.
Nonetheless, a proper fix is more future proof.
