### PR TITLE
Switch to gevent for worker executor pool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -395,5 +395,5 @@ develop_frontend: ## same as develop, but focus on frontend only
 	# shut everything down
 	${MAKE} down env=develop
 
-uv_lock: ## update the uv.lock file after changing pyproject.toml
+uv_lock uv.lock: ## update the uv.lock file after changing pyproject.toml
 	${DOCKER_COMPOSE_TOOLS_CMD} run --rm tools uv lock

--- a/checks/tasks/tls/tasks_reports.py
+++ b/checks/tasks/tls/tasks_reports.py
@@ -38,10 +38,6 @@ from checks.tasks.shared import (
 from checks.tasks.tls.http import http_checks
 from interface import batch, batch_shared_task, redis_id
 
-# Workaround for https://github.com/eventlet/eventlet/issues/413 for eventlet
-# while monkey patching. That way we can still catch subprocess.TimeoutExpired
-# instead of just Exception which may intervene with Celery's own exceptions.
-# Gevent does not have the same issue.
 from internetnl import log
 
 from checks.tasks.tls.scans import ChecksMode, cert_checks, has_daneTA, check_web_tls, check_mail_tls_multiple

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -227,7 +227,7 @@ services:
     # run as root because permission need to be set on batch_results directory, drop privileges in entrypoint.sh
     user: root
     entrypoint: /entrypoint-worker.sh
-    command: celery --app internetnl worker --without-gossip --pool=eventlet --time-limit=300 --concurrency=$WORKER_CONCURRENCY
+    command: celery --app internetnl worker --without-gossip --pool=gevent --time-limit=300 --concurrency=$WORKER_CONCURRENCY
       --queues default,celery,db_worker,ipv6_worker,mail_worker,web_worker,resolv_worker,dnssec_worker,rpki_worker,batch_main,batch_callback,batch_scheduler
     # time after which a SIGKILL is sent to celery after a SIGTERM (warm shutdown), default 10s
     # insufficient short grace period causes issues on batch when tasks are killed during the hourly worker restart
@@ -295,7 +295,7 @@ services:
       - SENTRY_DSN
       - SENTRY_ENVIRONMENT
       - SENTRY_SERVER_NAME
-      # even though eventlet is used and childs are not really threads or processes, this settings reduces
+      # even though gevent is used and childs are not really threads or processes, this settings reduces
       # issues with high memory usage, probably because some objects are freed?
       - CELERYD_MAX_TASKS_PER_CHILD=100
 
@@ -317,7 +317,7 @@ services:
     # disable swap by settings swap to the memory limit
     memswap_limit: $WORKER_NASSL_MEMORY_LIMIT
 
-    command: celery --app internetnl worker --without-gossip --pool=eventlet --time-limit=300 --concurrency=$WORKER_CONCURRENCY
+    command: celery --app internetnl worker --without-gossip --pool=gevent --time-limit=300 --concurrency=$WORKER_CONCURRENCY
       --queues nassl_worker,batch_nassl
     # set hostname for Sentry
     hostname: worker-nassl
@@ -334,7 +334,7 @@ services:
     deploy:
       replicas: $WORKER_SLOW_REPLICAS
 
-    command: celery --app internetnl worker --without-gossip --pool=eventlet --time-limit=600 --concurrency=$WORKER_SLOW_CONCURRENCY
+    command: celery --app internetnl worker --without-gossip --pool=gevent --time-limit=600 --concurrency=$WORKER_SLOW_CONCURRENCY
       --queues slow_db_worker,batch_slow
 
   # celery task queue

--- a/manage.py
+++ b/manage.py
@@ -1,15 +1,5 @@
 #!/usr/bin/env python3
 
-#from gevent import monkey
-#monkey.patch_all(aggressive=True)
-#from psycogreen.gevent import patch_psycopg
-#patch_psycopg()
-
-#import eventlet
-#eventlet.monkey_patch()
-#from psycogreen.eventlet import patch_psycopg
-#patch_psycopg()
-
 import os
 import sys
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "django-redis<5",
     "django-statsd-mozilla",
     "dnspython",
-    "eventlet",
     "forcediphttpsadapter",
     "gevent",
     "gitpython",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,7 +199,7 @@ def pytest_generate_tests(metafunc):
 # -----------------------------------------------------------------------------
 
 
-@pytest.fixture(params=["prefork", "gevent", "eventlet"])
+@pytest.fixture(params=["prefork", "gevent"])
 def custom_celery_worker(request):
     """Spawn celery worker to be used during test.
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,4 +1,4 @@
-# this tests if a task can be executed using gevent, eventlet, and to see if tasks with an unbound context also function
+# this tests if a task can be executed using gevent, and to see if tasks with an unbound context also function
 # This due to hanging tasks
 # import os
 
@@ -25,7 +25,7 @@ def wait_for_result(task_id):
 # @pytest.mark.skipif(os.getenv("GITHUB_ACTIONS", "") == "True", reason="Redis hang? at github actions")
 # @pytest.mark.skip
 def test_various_workers(custom_celery_worker):
-    """Simple test that starts a task on all different worker-types (gevent, prefork, eventlet) to
+    """Simple test that starts a task on all different worker-types (gevent, prefork) to
     verify that operations are normal. This requires a redis server to be reachable on the configured port in
     settings.py."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -633,19 +633,6 @@ wheels = [
 ]
 
 [[package]]
-name = "eventlet"
-version = "0.40.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dnspython" },
-    { name = "greenlet" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/d8/f72d8583db7c559445e0e9500a9b9787332370c16980802204a403634585/eventlet-0.40.4.tar.gz", hash = "sha256:69bef712b1be18b4930df6f0c495d2a882bf7b63aa111e7b6eeff461cfcaf26f", size = 565920, upload-time = "2025-11-26T13:57:31.126Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/6d/8e1fa901f6a8307f90e7bd932064e27a0062a4a7a16af38966a9c3293c52/eventlet-0.40.4-py3-none-any.whl", hash = "sha256:6326c6d0bf55810bece151f7a5750207c610f389ba110ffd1541ed6e5215485b", size = 364588, upload-time = "2025-11-26T13:57:29.09Z" },
-]
-
-[[package]]
 name = "flake8"
 version = "7.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -880,7 +867,6 @@ dependencies = [
     { name = "django-redis" },
     { name = "django-statsd-mozilla" },
     { name = "dnspython" },
-    { name = "eventlet" },
     { name = "forcediphttpsadapter" },
     { name = "gevent" },
     { name = "gitpython" },
@@ -958,7 +944,6 @@ requires-dist = [
     { name = "django-redis", specifier = "<5" },
     { name = "django-statsd-mozilla" },
     { name = "dnspython" },
-    { name = "eventlet" },
     { name = "forcediphttpsadapter" },
     { name = "gevent" },
     { name = "gitpython" },


### PR DESCRIPTION
- eventlet is deprecated and use is discouraged https://eventlet.readthedocs.io/en/latest/
- causes issues with threadpool in starttls