### PR TITLE
DMARCbis support

### DIFF
--- a/checks/models.py
+++ b/checks/models.py
@@ -1038,6 +1038,11 @@ class MxDomain(IPv6TestDomain):
 
 
 class DmarcPolicyStatus(LabelEnum):
+    """
+    `invalid_p_sp` is broader than its name suggests: it is also returned for
+    `t=y` (RFC 9989 test mode). Name is kept for batch API backwards compatibility
+    """
+
     valid = 0
     invalid_syntax = 1
     invalid_p_sp = 2

--- a/checks/models.py
+++ b/checks/models.py
@@ -1039,8 +1039,11 @@ class MxDomain(IPv6TestDomain):
 
 class DmarcPolicyStatus(LabelEnum):
     """
-    `invalid_p_sp` is broader than its name suggests: it is also returned for
-    `t=y` (RFC 9989 test mode). Name is kept for batch API backwards compatibility
+    `invalid_p_sp` is broader than its name suggests: it also covers
+    `p=quarantine; t=y` (RFC9989 test mode, which downgrades the applied
+    policy one level). `p=reject; t=y` is still valid
+    (downgrades to quarantine, which we accept). Name is kept for
+    batch API backwards compatibility.
     """
 
     valid = 0

--- a/checks/tasks/dmarc_parser.py
+++ b/checks/tasks/dmarc_parser.py
@@ -23,8 +23,8 @@ ParserElement.setDefaultWhitespaceChars("")  # Whitespace is in the grammar
 
 # Parser for DMARC records.
 #
-# The record is parsed based on section 6.4 (Formal Definition) of RFC-7489.
-# [ https://tools.ietf.org/html/rfc7489#section-6.4 ]
+# The record is parsed based on section 6.4 (Formal Definition) of RFC-7489,
+# [ https://tools.ietf.org/html/rfc7489#section-6.4 ], RFC 9091 and RFC9989.
 #
 # Most of the tokens have been combined together for easier access to the
 # records parts.
@@ -33,6 +33,8 @@ ParserElement.setDefaultWhitespaceChars("")  # Whitespace is in the grammar
 #     - request, (p=);
 #     - nrequest, (np=);
 #     - srequest, (sp=);
+#     - psd, (psd=);
+#     - testing, (t=);
 #     - auri, (rua=);
 #     - furi, (ruf=);
 #     - adkim, (adkim=);
@@ -111,6 +113,10 @@ nrequest = Combine(
     + equal
     + (CaselessLiteral("none") | CaselessLiteral("quarantine") | CaselessLiteral("reject"))
 )("nrequest")
+psd = Combine(CaselessLiteral("psd") + equal + (CaselessLiteral("y") | CaselessLiteral("n") | CaselessLiteral("u")))(
+    "psd"
+)
+testing = Combine(CaselessLiteral("t") + equal + (CaselessLiteral("y") | CaselessLiteral("n")))("testing")
 request = Combine(
     CaselessLiteral("p") + equal + (CaselessLiteral("none") | CaselessLiteral("quarantine") | CaselessLiteral("reject"))
 )("request")
@@ -120,6 +126,8 @@ directives = (
     + (
         Optional(sep + srequest)
         & Optional(sep + nrequest)
+        & Optional(sep + psd)
+        & Optional(sep + testing)
         & Optional(sep + auri)
         & Optional(sep + furi)
         & Optional(sep + adkim)

--- a/checks/tasks/mail.py
+++ b/checks/tasks/mail.py
@@ -513,8 +513,10 @@ def dmarc_check_policy(dmarc_record, domain, is_org_domain, public_suffix_list):
 
 def dmarc_verify_sufficient_policy(parsed, is_org_domain, public_suffix_list):
     """
-    Verify that the s=(sp=) policy is not 'none'.
+    Verify that the DMARC record provides effective protection.
 
+    The effective policy (`sp=` for org domains when present, else
+    `p=`) must not be `none`, and the record must not be in test mode (`t=y`).
     """
     status = DmarcPolicyStatus.valid
     score = scoring.MAIL_AUTH_DMARC_POLICY_PASS
@@ -545,8 +547,10 @@ def dmarc_verify_sufficient_policy(parsed, is_org_domain, public_suffix_list):
                     request = parsed["directives"]["request"]
 
             if request is not None:
-                value = request.split("=")[1]
-                if value.lower() == "none":
+                value = request.split("=")[1].lower()
+                testing = parsed["directives"].get("testing")
+                in_test_mode = testing is not None and testing.split("=")[1].lower() == "y"
+                if value == "none" or in_test_mode:
                     status = DmarcPolicyStatus.invalid_p_sp
                     score = scoring.MAIL_AUTH_DMARC_POLICY_PARTIAL
     return (status, score)

--- a/checks/tasks/mail.py
+++ b/checks/tasks/mail.py
@@ -515,8 +515,8 @@ def dmarc_verify_sufficient_policy(parsed, is_org_domain, public_suffix_list):
     """
     Verify that the DMARC record provides effective protection.
 
-    The effective policy (`sp=` for org domains when present, else
-    `p=`) must not be `none`, and the record must not be in test mode (`t=y`).
+    The effective policy is `sp=` for org domains when present, else `p=`.
+    A `t=y` (test mode, RFC9989) downgrades the applied policy one level.
     """
     status = DmarcPolicyStatus.valid
     score = scoring.MAIL_AUTH_DMARC_POLICY_PASS
@@ -550,7 +550,7 @@ def dmarc_verify_sufficient_policy(parsed, is_org_domain, public_suffix_list):
                 value = request.split("=")[1].lower()
                 testing = parsed["directives"].get("testing")
                 in_test_mode = testing is not None and testing.split("=")[1].lower() == "y"
-                if value == "none" or in_test_mode:
+                if value == "none" or (in_test_mode and value == "quarantine"):
                     status = DmarcPolicyStatus.invalid_p_sp
                     score = scoring.MAIL_AUTH_DMARC_POLICY_PARTIAL
     return (status, score)

--- a/checks/test/test_dmarc_parser.py
+++ b/checks/test/test_dmarc_parser.py
@@ -28,3 +28,33 @@ def test_parse():
     assert result.version == "v=DMARC1"
     assert result.directives.request == "p=none"
     assert result.directives.auri == "rua=mailto:dmarc@example.com"
+
+
+def test_parse_rfc9989_tags():
+    sample_record = "v=DMARC1; p=reject; sp=reject; np=reject; psd=n; t=y; rua=mailto:dmarc@example.com"
+    result = parse(sample_record)
+    assert result is not None
+    assert result.directives.psd == "psd=n"
+    assert result.directives.testing == "t=y"
+
+
+@pytest.mark.parametrize("value", ["y", "n", "u"])
+def test_parse_psd_values(value):
+    result = parse(f"v=DMARC1; p=none; psd={value}")
+    assert result is not None
+    assert result.directives.psd == f"psd={value}"
+
+
+def test_parse_psd_invalid_value():
+    assert parse("v=DMARC1; p=none; psd=x") is None
+
+
+@pytest.mark.parametrize("value", ["y", "n"])
+def test_parse_testing_values(value):
+    result = parse(f"v=DMARC1; p=none; t={value}")
+    assert result is not None
+    assert result.directives.testing == f"t={value}"
+
+
+def test_parse_testing_invalid_value():
+    assert parse("v=DMARC1; p=none; t=x") is None

--- a/interface/batch/openapi.yaml
+++ b/interface/batch/openapi.yaml
@@ -1062,8 +1062,11 @@ components:
                     * `valid` - The policy is valid and compliant.
                     * `invalid_syntax` - The policy is not syntactically correct.
                     * `invalid_p_sp` - The policy provides insufficient
-                      protection: either the effective 'p='/'sp=' value is
-                      'none', or the record is in test mode ('t=y').
+                      protection: the record declares no policy (no 'p='
+                      or, for organizational domains, no 'sp=' either),
+                      the effective policy is 'none', or the record is in
+                      test mode ('t=y', RFC 9989) with an effective policy
+                      of 'quarantine' (which t=y downgrades to 'none').
                     * `invalid_external` - The external destinations specified
                       in 'rua=' and/or 'ruf=' are not valid.
 

--- a/interface/batch/openapi.yaml
+++ b/interface/batch/openapi.yaml
@@ -1061,8 +1061,9 @@ components:
                     The validation status of the DMARC policy:
                     * `valid` - The policy is valid and compliant.
                     * `invalid_syntax` - The policy is not syntactically correct.
-                    * `invalid_p_sp` - The 'p=' or 'sp=' tag result in a less
-                      than compliant policy.
+                    * `invalid_p_sp` - The policy provides insufficient
+                      protection: either the effective 'p='/'sp=' value is
+                      'none', or the record is in test mode ('t=y').
                     * `invalid_external` - The external destinations specified
                       in 'rua=' and/or 'ruf=' are not valid.
 

--- a/tests/unittests/test_tasks_mail.py
+++ b/tests/unittests/test_tasks_mail.py
@@ -3,7 +3,29 @@ from unittest import skip
 from django.test import SimpleTestCase
 
 import checks
+from checks.models import DmarcPolicyStatus
 from checks.tasks import mail
+from checks.tasks.dmarc_parser import parse as dmarc_parse
+
+
+class DmarcVerifySufficientPolicyTestCase(SimpleTestCase):
+    def _verify(self, record, is_org_domain=False):
+        parsed = dmarc_parse(record)
+        status, _ = mail.dmarc_verify_sufficient_policy(parsed, is_org_domain, public_suffix_list=[])
+        return status
+
+    def test_strict_policy_is_valid(self):
+        self.assertEqual(self._verify("v=DMARC1; p=reject"), DmarcPolicyStatus.valid)
+
+    def test_none_policy_is_insufficient(self):
+        self.assertEqual(self._verify("v=DMARC1; p=none"), DmarcPolicyStatus.invalid_p_sp)
+
+    def test_test_mode_makes_strict_policy_insufficient(self):
+        """RFC 9989 `t=y` puts the policy in test mode; treat as `p=none`."""
+        self.assertEqual(self._verify("v=DMARC1; p=reject; t=y"), DmarcPolicyStatus.invalid_p_sp)
+
+    def test_test_mode_off_keeps_strict_policy_valid(self):
+        self.assertEqual(self._verify("v=DMARC1; p=reject; t=n"), DmarcPolicyStatus.valid)
 
 
 class DmarcNonSendingPolicyRegexTestCase(SimpleTestCase):

--- a/tests/unittests/test_tasks_mail.py
+++ b/tests/unittests/test_tasks_mail.py
@@ -14,18 +14,58 @@ class DmarcVerifySufficientPolicyTestCase(SimpleTestCase):
         status, _ = mail.dmarc_verify_sufficient_policy(parsed, is_org_domain, public_suffix_list=[])
         return status
 
-    def test_strict_policy_is_valid(self):
+    def test_reject_is_valid(self):
         self.assertEqual(self._verify("v=DMARC1; p=reject"), DmarcPolicyStatus.valid)
 
-    def test_none_policy_is_insufficient(self):
+    def test_quarantine_is_valid(self):
+        self.assertEqual(self._verify("v=DMARC1; p=quarantine"), DmarcPolicyStatus.valid)
+
+    def test_none_is_insufficient(self):
         self.assertEqual(self._verify("v=DMARC1; p=none"), DmarcPolicyStatus.invalid_p_sp)
 
-    def test_test_mode_makes_strict_policy_insufficient(self):
-        """RFC 9989 `t=y` puts the policy in test mode; treat as `p=none`."""
-        self.assertEqual(self._verify("v=DMARC1; p=reject; t=y"), DmarcPolicyStatus.invalid_p_sp)
+    def test_reject_with_test_mode_is_valid(self):
+        """RFC 9989 `t=y` downgrades reject to quarantine; we still accept that."""
+        self.assertEqual(self._verify("v=DMARC1; p=reject; t=y"), DmarcPolicyStatus.valid)
 
-    def test_test_mode_off_keeps_strict_policy_valid(self):
+    def test_quarantine_with_test_mode_is_insufficient(self):
+        """RFC 9989 `t=y` downgrades quarantine to none."""
+        self.assertEqual(self._verify("v=DMARC1; p=quarantine; t=y"), DmarcPolicyStatus.invalid_p_sp)
+
+    def test_none_with_test_mode_is_insufficient(self):
+        self.assertEqual(self._verify("v=DMARC1; p=none; t=y"), DmarcPolicyStatus.invalid_p_sp)
+
+    def test_test_mode_off_does_not_change_anything(self):
         self.assertEqual(self._verify("v=DMARC1; p=reject; t=n"), DmarcPolicyStatus.valid)
+        self.assertEqual(self._verify("v=DMARC1; p=quarantine; t=n"), DmarcPolicyStatus.valid)
+        self.assertEqual(self._verify("v=DMARC1; p=none; t=n"), DmarcPolicyStatus.invalid_p_sp)
+
+    def test_org_domain_sp_takes_precedence_and_gets_downgraded(self):
+        """`sp=` wins over `p=` for org domains, and the t=y downgrade
+        applies to the resulting effective policy."""
+        self.assertEqual(
+            self._verify("v=DMARC1; p=reject; sp=quarantine; t=y", is_org_domain=True),
+            DmarcPolicyStatus.invalid_p_sp,
+        )
+
+    def test_org_domain_falls_back_to_p_when_sp_absent(self):
+        """For org domains without `sp=`, the `p=` value is the effective
+        policy, and the t=y downgrade still applies to it."""
+        self.assertEqual(
+            self._verify("v=DMARC1; p=reject; t=y", is_org_domain=True),
+            DmarcPolicyStatus.valid,
+        )
+        self.assertEqual(
+            self._verify("v=DMARC1; p=quarantine; t=y", is_org_domain=True),
+            DmarcPolicyStatus.invalid_p_sp,
+        )
+
+    def test_org_domain_sp_none_is_insufficient(self):
+        """An explicit `sp=none` on an org domain is insufficient even
+        without t=, via the `value == "none"` branch."""
+        self.assertEqual(
+            self._verify("v=DMARC1; p=reject; sp=none", is_org_domain=True),
+            DmarcPolicyStatus.invalid_p_sp,
+        )
 
 
 class DmarcNonSendingPolicyRegexTestCase(SimpleTestCase):


### PR DESCRIPTION
- **Ref #2045 - Add psd/t tags from RFC9989 to DMARC parser**
  Per RFC7489 6.3 we might want to allow unknown tags in general.
  But for now, this adds and validates the new ones.
  

- **Ref #2045 - Reject DMARC record with t=y**
  If we reject p=none, I feel we should also reject t=y.
  This reuses the same status field which is now slightly misnamed,
  but not worth breaking API over.
  