### PR TITLE
Fixed rounding of score in the connection test

### DIFF
--- a/integration_tests/integration/test_connection.py
+++ b/integration_tests/integration/test_connection.py
@@ -9,9 +9,9 @@ import requests
 import re
 
 ALL_CONNECTION_PROBES = {"ipv6", "resolver"}
-TEST_CONNECTION_EXPECTED_SCORE = 100.0
+TEST_CONNECTION_EXPECTED_SCORE = 100
 # TODO: improve test environment to allow 100% score result
-TEST_CONNECTION_EXPECTED_SCORE = 50.0
+TEST_CONNECTION_EXPECTED_SCORE = 50
 
 
 def test_your_connection_score(page, app_url, app_domain):

--- a/interface/views/connection.py
+++ b/interface/views/connection.py
@@ -88,7 +88,7 @@ def results(request, request_id):
         connectionprobes["resolver"].rated_results_by_model(ct),
     ]
     scores = [pr["totalscore"] for pr in probereports]
-    score = max(min(sum(scores) / len(scores), 100), 0)
+    score = max(min(int(sum(scores) / len(scores)), 100), 0)
 
     return render(
         request,


### PR DESCRIPTION
There was an inconsistency between scoring rounding in the web/mail test versus connection test.

This breaks the connection test score on Chromium-based browsers (seems like Chromium uses a comma, Firebox uses a dot, not sure if that is why it breaks.

See also: https://github.com/internetstandards/Internet.nl/blob/134609a802ad3dca81cc90cb5f7f19acf898e454/checks/probes.py#L115