### PR TITLE
fix issues with gevent based workers

### DIFF
--- a/internetnl/settings.py
+++ b/internetnl/settings.py
@@ -291,8 +291,8 @@ CELERY_BROKER_HEARTBEAT = 0  # Workaround for https://github.com/celery/celery/i
 CELERY_TASK_ACKS_LATE = True
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 
-# fix redis connection leaks
-CELERY_RESULT_BACKEND_THREAD_SAFE = True
+# prevent issues with gevent based workers
+CELERY_RESULT_BACKEND_THREAD_SAFE = False
 
 # used for celery-exporter
 CELERY_WORKER_SEND_TASK_EVENTS = True

--- a/internetnl/settings.py
+++ b/internetnl/settings.py
@@ -292,6 +292,7 @@ CELERY_TASK_ACKS_LATE = True
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 
 # prevent issues with gevent based workers
+# https://github.com/internetstandards/Internet.nl/pull/2102
 CELERY_RESULT_BACKEND_THREAD_SAFE = False
 
 # used for celery-exporter


### PR DESCRIPTION
Gevent seems to cause issues with Redis result backend:

```
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,725: WARNING/MainProcess] Traceback (most recent call last):
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "src/gevent/greenlet.py", line 900, in gevent._gevent_cgreenlet.Greenlet.run
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/celery/backends/asynchronous.py", line 118, in run
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     self.result_consumer.drain_events(timeout=1)
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/celery/backends/redis.py", line 164, in drain_events
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     message = self._pubsub.get_message(timeout=timeout)
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/redis/client.py", line 1342, in get_message
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     response = self.parse_response(block=(timeout is None), timeout=timeout)
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/redis/client.py", line 1141, in parse_response
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     response = self._execute(conn, try_read)
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/redis/client.py", line 1094, in _execute
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     response = conn.retry.call_with_retry(
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:         lambda: command(*args, **kwargs),
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:         failure_callback,
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:         with_failure_count=True,
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     )
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/redis/retry.py", line 120, in call_with_retry
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     return do()
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/redis/client.py", line 1095, in <lambda>
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     lambda: command(*args, **kwargs),
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:             ~~~~~~~^^^^^^^^^^^^^^^^^
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/redis/client.py", line 1135, in try_read
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     if not conn.can_read(timeout=timeout):
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:            ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/redis/connection.py", line 1316, in can_read
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     return self._parser.can_read(timeout)
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:            ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/redis/_parsers/hiredis.py", line 102, in can_read
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     return self.read_from_socket(timeout=timeout, raise_on_timeout=False)
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:            ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/redis/_parsers/hiredis.py", line 111, in read_from_socket
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     bufflen = self._sock.recv_into(self._buffer)
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/gevent/_socketcommon.py", line 692, in recv_into
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     self._wait(self._read_event)
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     ~~~~~~~~~~^^^^^^^^^^^^^^^^^^
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "src/gevent/_hub_primitives.py", line 317, in gevent._gevent_c_hub_primitives.wait_on_socket
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "src/gevent/_hub_primitives.py", line 322, in gevent._gevent_c_hub_primitives.wait_on_socket
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "src/gevent/_hub_primitives.py", line 297, in gevent._gevent_c_hub_primitives._primitive_wait
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess] gevent.exceptions.ConcurrentObjectUseError: This socket is already used by another greenlet: <bound method Waiter.switch of <gevent._gevent_c_waiter.Waiter object at 0x7f506e502e30>>
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess] 2026-06-23T22:00:13Z
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess] <Greenlet at 0x7f50646eccc0: <bound method greenletDrainer.run of <celery.backends.asynchronous.geventDrainer object at 0x7f5064929550>>> failed with ConcurrentObjectUseError
```

Setting the Redis result backend to not thread safe in the hopes it won't cause more memory leaks again (the reason it was switched to thread safe). 