### PR TITLE
Fix redis connection leaks (again)

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -228,7 +228,7 @@ services:
     user: root
     entrypoint: /entrypoint-worker.sh
     command: celery --app internetnl worker --without-gossip --pool=gevent --time-limit=300 --concurrency=$WORKER_CONCURRENCY
-      --queues default,celery,db_worker,ipv6_worker,mail_worker,web_worker,resolv_worker,dnssec_worker,rpki_worker,batch_main,batch_callback,batch_scheduler
+      --queues default,celery,db_worker,ipv6_worker,mail_worker,web_worker,resolv_worker,dnssec_worker,rpki_worker,batch_main,batch_callback
     # time after which a SIGKILL is sent to celery after a SIGTERM (warm shutdown), default 10s
     # insufficient short grace period causes issues on batch when tasks are killed during the hourly worker restart
     stop_grace_period: 10m
@@ -336,6 +336,15 @@ services:
 
     command: celery --app internetnl worker --without-gossip --pool=gevent --time-limit=600 --concurrency=$WORKER_SLOW_CONCURRENCY
       --queues slow_db_worker,batch_slow
+
+  # prefork worker for batch scheduling. Avoids issue https://github.com/internetstandards/Internet.nl/pull/2106 after switching to gevent
+  worker-scheduler:
+    <<: *worker
+    deploy:
+      replicas: $WORKER_SCHEDULER_REPLICAS
+    command: celery --app internetnl worker --without-gossip --pool=prefork --time-limit=300 --concurrency=$WORKER_SCHEDULER_CONCURRENCY
+      --queues batch_scheduler
+    hostname: worker-scheduler
 
   # celery task queue
   beat:

--- a/docker/defaults.env
+++ b/docker/defaults.env
@@ -210,6 +210,11 @@ WORKER_SLOW_MEMORY_LIMIT=5G
 # limit number of slow worker replicas to 1 to prevent to much concurrent processes
 WORKER_SLOW_REPLICAS=1
 
+# Worker to run batch sheduler which queues batch domains for scanning, needs separate worker without
+# gevent/eventlet to avoid concurrency issues or redis connection leaks: https://github.com/internetstandards/Internet.nl/pull/2106
+WORKER_SCHEDULER_CONCURRENCY=1
+WORKER_SCHEDULER_REPLICAS=1
+
 # Separate worker for tasks which suffer from a lot of memory leaks. This worker gets restarted at regular
 # interval to mitigate the memory issues, it also gets a little more  memory allocated for that reason.
 WORKER_NASSL_MEMORY_LIMIT=5G

--- a/documentation/Docker-container-profiles.md
+++ b/documentation/Docker-container-profiles.md
@@ -3,31 +3,32 @@
 This overview was last generated with `make update_container_documentation`.
 
 
-| container             | profiles     | description                                                                                                                      |
-|-----------------------|--------------|----------------------------------------------------------------------------------------------------------------------------------|
-| webserver             |              | nginx proxy container, also runs certbot                                                                                         |
-| app                   |              | django container                                                                                                                 |
-| db-migrate            |              | django DB migrations, runs to completion and exits with 0                                                                        |
-| worker                |              |                                                                                                                                  |
-| worker-nassl          |              | worker for queue with potential memory leak                                                                                      |
-| worker-slow           |              | worker for slow and long running tasks that could require a lot of memory (eg: hof update)                                       |
-| beat                  |              | celery task queue                                                                                                                |
-| redis                 |              | redis caches state, also used for:<br>- MAC address lookup<br>- Django page cache<br>- client DNS resolver IPs in connectiontest |
-| rabbitmq              |              | rabbitmq message-broker                                                                                                          |
-| postgres              |              | database                                                                                                                         |
-| routinator            | routinator   | for RPKI                                                                                                                         |
-| unbound               |              | unbound DNS server used for connection test                                                                                      |
-| resolver-validating   |              | unbound resolver used for ldns-dane that require DNSSEC validation                                                               |
-| cron                  |              | cron with periodic tasks                                                                                                         |
-| cron-docker           |              | cron daemon with access to Docker socket but no networking                                                                       |
-| grafana               | monitoring   |                                                                                                                                  |
-| prometheus            | monitoring   |                                                                                                                                  |
-| alertmanager          | alertmanager | requires monitoring profile                                                                                                      |
-| postgresql-exporter   | monitoring   |                                                                                                                                  |
-| redis-exporter        | monitoring   |                                                                                                                                  |
-| statsd-exporter       | monitoring   |                                                                                                                                  |
-| celery-exporter       | monitoring   |                                                                                                                                  |
-| node-exporter         | monitoring   |                                                                                                                                  |
-| docker_stats_exporter | monitoring   |                                                                                                                                  |
-| nginx_logs_exporter   | monitoring   |                                                                                                                                  |
-| query-exporter        | monitoring   |                                                                                                                                  |
+| container             | profiles     | description                                                                                                                            |
+|-----------------------|--------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| webserver             |              | nginx proxy container, also runs certbot                                                                                               |
+| app                   |              | django container                                                                                                                       |
+| db-migrate            |              | django DB migrations, runs to completion and exits with 0                                                                              |
+| worker                |              |                                                                                                                                        |
+| worker-nassl          |              | worker for queue with potential memory leak                                                                                            |
+| worker-slow           |              | worker for slow and long running tasks that could require a lot of memory (eg: hof update)                                             |
+| worker-scheduler      |              | prefork worker for batch scheduling. Avoids issue https://github.com/internetstandards/Internet.nl/pull/2106 after switching to gevent |
+| beat                  |              | celery task queue                                                                                                                      |
+| redis                 |              | redis caches state, also used for:<br>- MAC address lookup<br>- Django page cache<br>- client DNS resolver IPs in connectiontest       |
+| rabbitmq              |              | rabbitmq message-broker                                                                                                                |
+| postgres              |              | database                                                                                                                               |
+| routinator            | routinator   | for RPKI                                                                                                                               |
+| unbound               |              | unbound DNS server used for connection test                                                                                            |
+| resolver-validating   |              | unbound resolver used for ldns-dane that require DNSSEC validation                                                                     |
+| cron                  |              | cron with periodic tasks                                                                                                               |
+| cron-docker           |              | cron daemon with access to Docker socket but no networking                                                                             |
+| grafana               | monitoring   |                                                                                                                                        |
+| prometheus            | monitoring   |                                                                                                                                        |
+| alertmanager          | alertmanager | requires monitoring profile                                                                                                            |
+| postgresql-exporter   | monitoring   |                                                                                                                                        |
+| redis-exporter        | monitoring   |                                                                                                                                        |
+| statsd-exporter       | monitoring   |                                                                                                                                        |
+| celery-exporter       | monitoring   |                                                                                                                                        |
+| node-exporter         | monitoring   |                                                                                                                                        |
+| docker_stats_exporter | monitoring   |                                                                                                                                        |
+| nginx_logs_exporter   | monitoring   |                                                                                                                                        |
+| query-exporter        | monitoring   |                                                                                                                                        |

--- a/internetnl/settings.py
+++ b/internetnl/settings.py
@@ -291,9 +291,8 @@ CELERY_BROKER_HEARTBEAT = 0  # Workaround for https://github.com/celery/celery/i
 CELERY_TASK_ACKS_LATE = True
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 
-# prevent issues with gevent based workers
-# https://github.com/internetstandards/Internet.nl/pull/2102
-CELERY_RESULT_BACKEND_THREAD_SAFE = False
+# fix redis connection leaks
+CELERY_RESULT_BACKEND_THREAD_SAFE = True
 
 # used for celery-exporter
 CELERY_WORKER_SEND_TASK_EVENTS = True


### PR DESCRIPTION
Timeline:
- Changes in TLS checks caused timeouts/hanging tasks 
- Eventlet cannot properly kill tasks, even when task timeout is set
- Switched to gevent which does properly handle task timeout
- Gevent (monkeypatching?) causes issues with Redis socket concurrency
- Changed to thread unsafe celery redis result backend
- Introduced Redis connection leaks again

This PR restores the thread safe celery redis result backend and moves the batch scheduler task to a separate prefork (non gevent/eventlet) worker, as this seems is the only task effected by this issue.

original issue after moving to gevent: 
```
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,725: WARNING/MainProcess] Traceback (most recent call last):
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "src/gevent/greenlet.py", line 900, in gevent._gevent_cgreenlet.Greenlet.run
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/celery/backends/asynchronous.py", line 118, in run
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     self.result_consumer.drain_events(timeout=1)
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/celery/backends/redis.py", line 164, in drain_events
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     message = self._pubsub.get_message(timeout=timeout)
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/redis/client.py", line 1342, in get_message
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     response = self.parse_response(block=(timeout is None), timeout=timeout)
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/redis/client.py", line 1141, in parse_response
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     response = self._execute(conn, try_read)
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/redis/client.py", line 1094, in _execute
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     response = conn.retry.call_with_retry(
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:         lambda: command(*args, **kwargs),
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:         failure_callback,
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:         with_failure_count=True,
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     )
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/redis/retry.py", line 120, in call_with_retry
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     return do()
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/redis/client.py", line 1095, in <lambda>
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     lambda: command(*args, **kwargs),
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:             ~~~~~~~^^^^^^^^^^^^^^^^^
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/redis/client.py", line 1135, in try_read
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     if not conn.can_read(timeout=timeout):
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:            ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/redis/connection.py", line 1316, in can_read
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     return self._parser.can_read(timeout)
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:            ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/redis/_parsers/hiredis.py", line 102, in can_read
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     return self.read_from_socket(timeout=timeout, raise_on_timeout=False)
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:            ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/redis/_parsers/hiredis.py", line 111, in read_from_socket
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     bufflen = self._sock.recv_into(self._buffer)
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "/usr/local/lib/python3.13/dist-packages/gevent/_socketcommon.py", line 692, in recv_into
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     self._wait(self._read_event)
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]:     ~~~~~~~~~~^^^^^^^^^^^^^^^^^^
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "src/gevent/_hub_primitives.py", line 317, in gevent._gevent_c_hub_primitives.wait_on_socket
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "src/gevent/_hub_primitives.py", line 322, in gevent._gevent_c_hub_primitives.wait_on_socket
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]   File "src/gevent/_hub_primitives.py", line 297, in gevent._gevent_c_hub_primitives._primitive_wait
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess] gevent.exceptions.ConcurrentObjectUseError: This socket is already used by another greenlet: <bound method Waiter.switch of <gevent._gevent_c_waiter.Waiter object at 0x7f506e502e30>>
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess] 2026-06-23T22:00:13Z
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess]
Jun 24 00:00:13 int-dev-docker internetnl-dev1-worker-2[926]: [2026-06-23 22:00:13,727: WARNING/MainProcess] <Greenlet at 0x7f50646eccc0: <bound method greenletDrainer.run of <celery.backends.asynchronous.geventDrainer object at 0x7f5064929550>>> failed with ConcurrentObjectUseError
```

which is solved by moving the scheduler task to a prefork worker