### PR TITLE
Handle malformed redirect URLs in HTTP checks

### DIFF
--- a/checks/http_client.py
+++ b/checks/http_client.py
@@ -74,9 +74,11 @@ def http_get(
         # Retry, once, then log and raise the exception
         try:
             response = _do_request(args, headers, kwargs, session, url)
-        except requests.RequestException as exc:
+        except (requests.RequestException, urllib3.exceptions.LocationParseError) as exc:
             log.debug(f"HTTP request raised exception: {url} (headers: {headers}): {exc}")
-            raise exc
+            if isinstance(exc, requests.RequestException):
+                raise
+            raise requests.exceptions.InvalidURL(str(exc)) from exc
 
     log.debug(f"HTTP request completed in {timer()-start_time:.06f}s: {url} (headers: {headers})")
     return response

--- a/checks/test_http_client.py
+++ b/checks/test_http_client.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+
+import pytest
+import requests
+from urllib3.exceptions import LocationParseError
+
+from checks.http_client import http_get
+
+
+class InvalidRedirectSession:
+    def __init__(self):
+        self.calls = 0
+        self.initial_response = requests.Response()
+        self.initial_response.status_code = 302
+        self.initial_response.url = "https://example.test/"
+        self.initial_response.history = []
+        self.initial_response._next = SimpleNamespace(url="https://./")
+
+    def get(self, *args, **kwargs):
+        self.calls += 1
+        if self.calls % 2:
+            return self.initial_response
+        raise LocationParseError(".")
+
+
+def test_http_get_normalizes_malformed_redirect_error():
+    session = InvalidRedirectSession()
+
+    with pytest.raises(requests.exceptions.InvalidURL) as exc_info:
+        http_get("https://example.test/", session=session)
+
+    assert isinstance(exc_info.value.__cause__, LocationParseError)
+    assert session.calls == 4


### PR DESCRIPTION
A persistent malformed redirect such as `https://./` currently leaks urllib3's `LocationParseError`, bypassing callers that handle `requests.RequestException` and aborting checks such as IPv4/IPv6 content comparison. Normalize it to Requests' `InvalidURL` after the existing retry, with a focused regression test for the retry path.

Fixes #2032.
